### PR TITLE
Fix GPK file redirect to use exact match instead of substring

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1692,7 +1692,7 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 
 		for (const auto &[filename, full_file_path] : additional_granny_files)
 		{
-			if (strstr(pathComponent, filename.c_str()))
+			if (strcmp(pathComponent, filename.c_str()) == 0)
 			{
 				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
 


### PR DESCRIPTION
The current strstr(pathComponent, filename) check causes substring collisions.
For example, registering Hecate.gpk in additional_granny_files also matches WeaponHecate.gpk, redirecting the weapon model to the character GPK.
This breaks any character whose name is a substring of another GPK filename.

This uses strcmp for exact matching, consistent with how the game resolves filenames.
The pathComponent passed to this hook is already the resolved filename, so exact match is correct.