### PR TITLE
feat(sjson): discover and inject sjson files from plugins_data

### DIFF
--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -479,7 +479,7 @@ namespace lua::hades::data
 
 		// Lua API: Function
 		// Table: data
-		// Name: register_content_file
+		// Name: register_sjson_file
 		// Param: absolute_path: string: The absolute filesystem path to a .sjson file inside a <SJSON_DATA_DIR_NAME> directory.
 		// Returns: boolean: true if registered successfully, false if the file is a duplicate, not a .sjson, or the path does not contain <SJSON_DATA_DIR_NAME>.
 		// Registers a .sjson file so the engine discovers and loads it as if it were in the game's `Content/Game/` directory.
@@ -487,13 +487,13 @@ namespace lua::hades::data
 		// For example, `plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/Foo.sjson` is loaded as `Content/Game/Animations/Foo.sjson`.
 		// At startup, Hell2Modding automatically scans every mod's <SJSON_DATA_DIR_NAME> directory and registers any .sjson files found.
 		// Use this function to dynamically register files created during the current session (e.g. a first-time install placing a file into plugins_data).
-		ns.set_function("register_content_file", [](const std::string& absolute_path) -> bool {
+		ns.set_function("register_sjson_file", [](const std::string& absolute_path) -> bool {
 			std::string normalized = sjson_overlay::normalize_path(absolute_path);
 			const std::string marker = std::string(sjson_overlay::SJSON_DATA_DIR_NAME) + "/";
 			auto pos = normalized.find(marker);
 			if (pos == std::string::npos)
 			{
-				LOG(WARNING) << "[SJSON] register_content_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
+				LOG(WARNING) << "[SJSON] register_sjson_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
 				return false;
 			}
 			// Convention: <SJSON_DATA_DIR_NAME> implicitly maps to Game/ in Content

--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -1,6 +1,7 @@
 #include "data.hpp"
 
 #include "hades_ida.hpp"
+#include "sjson_overlay.hpp"
 
 #include <hades2/pdb_symbol_map.hpp>
 #include <hooks/hooking.hpp>
@@ -227,7 +228,29 @@ namespace lua::hades::data
 			{
 				std::scoped_lock l(big::lua_manager_extension::g_manager_mutex);
 
-				g_sjson_FileStream_to_filepath[g_current_file_stream] = output_;
+				// If the output was redirected to an SJSON overlay path, it won't match sjson.hook filters
+				// sjson.hook filters use Content/ paths, which we need to reconstruct
+				// The base path is the ResourceDirectory root (e.g. "C:\...\Content\Game\Animations"), and pathComponent is the filename
+				// We check if the output contains the overlay marker and fall back to the original path
+				std::string output_str = (char*)output_.u8string().c_str();
+				if (output_str.find(sjson_overlay::SJSON_DATA_DIR_NAME) != std::string::npos)
+				{
+					// Output was redirected to overlay - build the original Content/ path instead
+					char original_path[512];
+					strncpy(original_path, basePath, sizeof(original_path) - 1);
+					original_path[sizeof(original_path) - 1] = '\0';
+					size_t base_len = strlen(original_path);
+					if (base_len > 0 && original_path[base_len - 1] != '\\' && original_path[base_len - 1] != '/')
+					{
+						strncat(original_path, "\\", sizeof(original_path) - base_len - 1);
+					}
+					strncat(original_path, pathComponent, sizeof(original_path) - strlen(original_path) - 1);
+					g_sjson_FileStream_to_filepath[g_current_file_stream] = original_path;
+				}
+				else
+				{
+					g_sjson_FileStream_to_filepath[g_current_file_stream] = output_;
+				}
 			}
 		}
 	}
@@ -444,6 +467,49 @@ namespace lua::hades::data
 
 		ns.set_function("load_package_overrides_get", load_package_overrides_get);
 		ns.set_function("load_package_overrides_set", load_package_overrides_set);
+
+		// Lua API: Field
+		// Table: data
+		// Name: SJSON_DATA_DIR_NAME
+		// Value: "Hell2Modding-SJSON"
+		// The canonical directory name for the SJSON data overlay.
+		// Mods must place .sjson files in plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/, Text/{lang}/, etc.
+		// Hell2Modding scans this directory at startup and injects discovered .sjson files into the engine's loading pipeline.
+		ns["SJSON_DATA_DIR_NAME"] = sjson_overlay::SJSON_DATA_DIR_NAME;
+
+		// Lua API: Function
+		// Table: data
+		// Name: register_content_file
+		// Param: absolute_path: string: The absolute filesystem path to a .sjson file inside a <SJSON_DATA_DIR_NAME> directory.
+		// Returns: boolean: true if registered successfully, false if the file is a duplicate, not a .sjson, or the path does not contain <SJSON_DATA_DIR_NAME>.
+		// Registers a .sjson file so the engine discovers and loads it as if it were in the game's `Content/Game/` directory.
+		// The engine-relative path is inferred automatically: files inside `plugins_data/<mod>/<SJSON_DATA_DIR_NAME>/` map to `Content/Game/`.
+		// For example, `plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/Foo.sjson` is loaded as `Content/Game/Animations/Foo.sjson`.
+		// At startup, Hell2Modding automatically scans every mod's <SJSON_DATA_DIR_NAME> directory and registers any .sjson files found.
+		// Use this function to dynamically register files created during the current session (e.g. a first-time install placing a file into plugins_data).
+		ns.set_function("register_content_file", [](const std::string& absolute_path) -> bool {
+			std::string normalized = sjson_overlay::normalize_path(absolute_path);
+			const std::string marker = std::string(sjson_overlay::SJSON_DATA_DIR_NAME) + "/";
+			auto pos = normalized.find(marker);
+			if (pos == std::string::npos)
+			{
+				LOG(WARNING) << "[SJSON] register_content_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
+				return false;
+			}
+			// Convention: <SJSON_DATA_DIR_NAME> implicitly maps to Game/ in Content
+			std::string logical_relpath = "Game/" + normalized.substr(pos + marker.size());
+			return sjson_overlay::register_content_file(logical_relpath, absolute_path);
+		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: register_content_directory
+		// Param: absolute_base_path: string: Absolute path to a directory whose structure mirrors `Content/Game/` (e.g. containing `Animations/`, `Text/en/`, etc.)
+		// Scans the directory recursively and registers all .sjson files found. Each file's engine path is derived from its position in the directory tree.
+		// This is the same scan that Hell2Modding performs automatically at startup for `plugins_data/*/<SJSON_DATA_DIR_NAME>/`.
+		ns.set_function("register_content_directory", [](const std::string& absolute_base_path) {
+			sjson_overlay::scan_content_directory(std::filesystem::path(absolute_base_path));
+		});
 
 		state["sol.__h2m_LoadPackages__"] = state["LoadPackages"];
 		// Lua API: Function

--- a/src/lua_extensions/lua_module_ext.hpp
+++ b/src/lua_extensions/lua_module_ext.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "bindings/hades/inputs.hpp"
+#include "sjson_overlay.hpp"
 #include "lua/lua_module.hpp"
+
+#include <paths/paths.hpp>
 
 namespace big
 {
@@ -32,11 +35,13 @@ namespace big
 		lua_module_ext(const module_info& module_info, sol::environment& env) :
 		    lua_module(module_info, env)
 		{
+			set_sjson_data_path();
 		}
 
 		lua_module_ext(const module_info& module_info, sol::state_view& state) :
 		    lua_module(module_info, state)
 		{
+			set_sjson_data_path();
 		}
 
 		inline void cleanup() override
@@ -44,6 +49,19 @@ namespace big
 			lua_module::cleanup();
 
 			m_data_ext = {};
+		}
+
+	private:
+		void set_sjson_data_path()
+		{
+			auto sjson_data_path = g_file_manager.get_project_folder("plugins_data").get_path() / m_info.m_guid / sjson_overlay::SJSON_DATA_DIR_NAME;
+			auto sjson_data_path_string = std::string(reinterpret_cast<const char*>(sjson_data_path.u8string().c_str()));
+
+			sol::table ns = m_env["_PLUGIN"];
+			if (ns.valid())
+			{
+				ns["sjson_data_path"] = sjson_data_path_string;
+			}
 		}
 	};
 } // namespace big

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1706,26 +1706,18 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 		}
 
 		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		std::string normalized_output = sjson_overlay::normalize_path(output);
+		std::string lower_output = big::string::to_lower(normalized_output);
+		auto content_pos = lower_output.rfind("content/");
+		if (content_pos != std::string::npos)
 		{
-			std::string normalized_output = sjson_overlay::normalize_path(output);
-			std::string lower_output = big::string::to_lower(normalized_output);
-			auto content_pos = lower_output.rfind("content/");
-			if (content_pos != std::string::npos)
+			std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
+			std::string redirect_abspath = sjson_overlay::lookup_overlay_path(logical_path);
+			if (!redirect_abspath.empty())
 			{
-				std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
-				std::string overlay_abspath = sjson_overlay::lookup_overlay_path(logical_path);
-				if (!overlay_abspath.empty())
-				{
-					if (overlay_abspath.size() < 512)
-					{
-						LOG(DEBUG) << "[SJSON] Redirecting '" << logical_path << "' -> '" << overlay_abspath << "'";
-						strcpy(output, overlay_abspath.c_str());
-					}
-					else
-					{
-						LOG(WARNING) << "[SJSON] Overlay path too long (>511 bytes), skipping: " << overlay_abspath;
-					}
-				}
+				LOG(DEBUG) << pathComponent << " | " << logical_path << " | " << redirect_abspath;
+
+				strcpy(output, redirect_abspath.c_str());
 			}
 		}
 	}
@@ -1815,7 +1807,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 
 		std::string normalized_subdir = sjson_overlay::normalize_path(subDirectory);
 
-		// Only process .sjson file enumerations
 		if (ext_clean != ".sjson")
 		{
 			return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1821,9 +1821,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			return;
 		}
 
-		// Mark this directory as enumerated so late registrations get a warning
-		sjson_overlay::mark_directory_enumerated(normalized_subdir, ext_clean);
-
 		// Determine the engine's target directory relative to Content/Game/ so we can match overlay files.
 		// resolved_base_dir is the physical path the engine is scanning (e.g. "C:/.../Content/Game/Animations").
 		// We extract the part after "Content/Game/" to get e.g. "Animations".
@@ -1852,6 +1849,9 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 				full_engine_subdir = normalized_subdir;
 			}
 		}
+
+		// Mark using the full logical directory (game/<subdir>) so it matches the keys used by register_content_file for late-registration warnings
+		sjson_overlay::mark_directory_enumerated("game/" + full_engine_subdir, ext_clean);
 
 		// Match overlay files whose directory matches the engine's target
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1864,13 +1864,13 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
 			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
 			{
-				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
+				// relpath keys are lowercase, e.g. "game/animations/foo.sjson" - strip "game/" prefix
 				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
-				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "game/")
 				{
 					continue;
 				}
-				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "animations/foo.sjson"
 
 				// Check extension
 				auto dot_pos = game_relative.rfind('.');

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1864,13 +1864,13 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
 			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
 			{
-				// relpath keys are lowercase, e.g. "game/animations/foo.sjson" - strip "game/" prefix
+				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
 				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
-				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "game/")
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
 				{
 					continue;
 				}
-				std::string game_relative = normalized_relpath.substr(5); // e.g. "animations/foo.sjson"
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
 
 				// Check extension
 				auto dot_pos = game_relative.rfind('.');

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "threads/thread_pool.hpp"
 #include "threads/util.hpp"
 #include "version.hpp"
+#include "sjson_overlay.hpp"
 
 #include <DbgHelp.h>
 #include <hades2/pdb_symbol_map.hpp>
@@ -1703,12 +1704,51 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 				break;
 			}
 		}
+
+		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		{
+			std::string normalized_output = sjson_overlay::normalize_path(output);
+			std::string lower_output = big::string::to_lower(normalized_output);
+			auto content_pos = lower_output.rfind("content/");
+			if (content_pos != std::string::npos)
+			{
+				std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
+				std::string overlay_abspath = sjson_overlay::lookup_overlay_path(logical_path);
+				if (!overlay_abspath.empty())
+				{
+					if (overlay_abspath.size() < 512)
+					{
+						LOG(DEBUG) << "[SJSON] Redirecting '" << logical_path << "' -> '" << overlay_abspath << "'";
+						strcpy(output, overlay_abspath.c_str());
+					}
+					else
+					{
+						LOG(WARNING) << "[SJSON] Overlay path too long (>511 bytes), skipping: " << overlay_abspath;
+					}
+				}
+			}
+		}
 	}
 }
 
 static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char *subDirectory, wchar_t *extension, eastl::vector<eastl::string> *out)
 {
 	big::g_hooking->get_original<hook_fsGetFilesWithExtension_packages>()(resourceDir, subDirectory, extension, out);
+
+	// Resolve the ResourceDirectory to its physical path so we can match the correct sjson files (and not include those that belong to a different group)
+	std::string resolved_base_dir;
+	{
+		static auto fsGetResourceDirectory_ptr = big::hades2_symbol_to_address["fsGetResourceDirectory"];
+		if (fsGetResourceDirectory_ptr)
+		{
+			static auto fsGetResourceDirectory = fsGetResourceDirectory_ptr.as_func<const char*(PVOID)>();
+			const char* base = fsGetResourceDirectory(resourceDir);
+			if (base)
+			{
+				resolved_base_dir = sjson_overlay::normalize_path(base);
+			}
+		}
+	}
 
 	bool has_pkg_manifest = false;
 	bool has_pkg          = false;
@@ -1754,6 +1794,133 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 		for (const auto &[filename, full_file_path] : additional_granny_files)
 		{
 			out->push_back(filename.c_str());
+		}
+	}
+
+	// SJSON overlay: inject additional .sjson files into the engine's enumeration
+	if (subDirectory && extension)
+	{
+		// The extension parameter is char* despite the wchar_t* in the hook signature
+		const char* ext_as_char = reinterpret_cast<const char*>(extension);
+		if (!ext_as_char || ext_as_char[0] == '\0')
+		{
+			return;
+		}
+
+		std::string ext_clean(ext_as_char);
+		if (ext_clean.size() > 1 && ext_clean[0] == '*')
+		{
+			ext_clean = ext_clean.substr(1);
+		}
+
+		std::string normalized_subdir = sjson_overlay::normalize_path(subDirectory);
+
+		// Only process .sjson file enumerations
+		if (ext_clean != ".sjson")
+		{
+			return;
+		}
+
+		// Mark this directory as enumerated so late registrations get a warning
+		sjson_overlay::mark_directory_enumerated(normalized_subdir, ext_clean);
+
+		// Determine the engine's target directory relative to Content/Game/ so we can match overlay files.
+		// resolved_base_dir is the physical path the engine is scanning (e.g. "C:/.../Content/Game/Animations").
+		// We extract the part after "Content/Game/" to get e.g. "Animations".
+		std::string engine_game_subdir;
+		if (!resolved_base_dir.empty())
+		{
+			std::string lower_base = big::string::to_lower(resolved_base_dir);
+
+			auto game_pos = lower_base.find("content/game/");
+			if (game_pos != std::string::npos)
+			{
+				engine_game_subdir = resolved_base_dir.substr(game_pos + 13);
+			}
+		}
+
+		// Combine engine base subdir with the subDirectory parameter for nested scans (e.g. Text/{lang})
+		std::string full_engine_subdir = engine_game_subdir;
+		if (!normalized_subdir.empty())
+		{
+			if (!full_engine_subdir.empty())
+			{
+				full_engine_subdir += "/" + normalized_subdir;
+			}
+			else
+			{
+				full_engine_subdir = normalized_subdir;
+			}
+		}
+
+		// Match overlay files whose directory matches the engine's target
+		{
+			std::unordered_set<std::string> existing;
+			for (const auto& existing_file : *out)
+			{
+				existing.insert(existing_file.c_str());
+			}
+
+			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
+			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
+			{
+				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
+				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
+				{
+					continue;
+				}
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
+
+				// Check extension
+				auto dot_pos = game_relative.rfind('.');
+				if (dot_pos == std::string::npos || game_relative.substr(dot_pos) != ext_clean)
+				{
+					continue;
+				}
+
+				// Extract file's directory and filename
+				auto slash_pos = game_relative.rfind('/');
+				std::string file_subdir;
+				std::string filename;
+				if (slash_pos != std::string::npos)
+				{
+					file_subdir = game_relative.substr(0, slash_pos);
+					filename = game_relative.substr(slash_pos + 1);
+				}
+				else
+				{
+					file_subdir = "";
+					filename = game_relative;
+				}
+
+				// Case-insensitive directory comparison
+				std::string lower_file_subdir = big::string::to_lower(file_subdir);
+				std::string lower_full_engine_subdir = big::string::to_lower(full_engine_subdir);
+
+				if (lower_file_subdir != lower_full_engine_subdir)
+				{
+					continue;
+				}
+
+				// Build the entry in the format the engine expects
+				std::string entry_to_inject;
+				if (!normalized_subdir.empty())
+				{
+					entry_to_inject = normalized_subdir + "\\" + filename;
+				}
+				else
+				{
+					entry_to_inject = filename;
+				}
+
+				if (existing.find(entry_to_inject) == existing.end())
+				{
+					out->push_back(entry_to_inject.c_str());
+					existing.insert(entry_to_inject);
+					LOG(DEBUG) << "[SJSON] Injected '" << entry_to_inject << "' into " << full_engine_subdir;
+				}
+			}
 		}
 	}
 }
@@ -2645,6 +2812,9 @@ extern "C" __declspec(dllexport) void my_main()
 			LOG(INFO) << "Adding to granny files: " << (char *)entry.path().u8string().c_str();
 		}
 	}
+
+	// Scan for SJSON overlay files (plugins_data/*/<SJSON_DATA_DIR_NAME>/)
+	sjson_overlay::scan_all_plugin_content_directories(g_file_manager.get_project_folder("plugins_data").get_path());
 
 	const auto res = lovely_init((const char *)g_file_manager.get_project_folder("plugins").get_path().u8string().c_str());
 	LOG(INFO) << "lovely_init returned " << (int32_t)res;

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -1,0 +1,172 @@
+#include "sjson_overlay.hpp"
+
+#include <string/string.hpp>
+
+namespace sjson_overlay
+{
+	std::string normalize_path(const std::string& path)
+	{
+		std::string result = path;
+		std::replace(result.begin(), result.end(), '\\', '/');
+		while (!result.empty() && result.back() == '/')
+		{
+			result.pop_back();
+		}
+		return result;
+	}
+
+	bool is_known_engine_directory(const std::string& normalized_subdir)
+	{
+		std::string lower = big::string::to_lower(normalized_subdir);
+
+		// Check for text directories: game/text/{locale}
+		if (lower.find("game/text/") == 0)
+		{
+			std::string locale = lower.substr(10); // len("game/text/") = 10
+			for (const auto& known_locale : g_known_text_locales)
+			{
+				if (locale == known_locale)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		for (const auto& known : g_known_engine_directories)
+		{
+			if (lower == known)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
+	{
+		std::string normalized = normalize_path(logical_relpath);
+
+		// Extract directory and extension
+		std::string subdir;
+		std::string filename;
+		auto last_slash = normalized.rfind('/');
+		if (last_slash != std::string::npos)
+		{
+			subdir   = normalized.substr(0, last_slash);
+			filename = normalized.substr(last_slash + 1);
+		}
+		else
+		{
+			filename = normalized;
+		}
+
+		std::string extension;
+		auto dot_pos = filename.rfind('.');
+		if (dot_pos != std::string::npos)
+		{
+			extension = filename.substr(dot_pos);
+		}
+
+		if (big::string::to_lower(extension) != ".sjson")
+		{
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
+			return false;
+		}
+
+		if (!is_known_engine_directory(subdir))
+		{
+			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
+			             << "' is in a directory not known to be scanned by the engine. "
+			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
+			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
+		}
+
+		std::unique_lock lock(g_overlay_mutex);
+
+		if (g_path_index.count(normalized))
+		{
+			return false;
+		}
+
+		g_path_index[normalized] = absolute_path;
+
+		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
+		if (g_enumerated_directories.count(enum_key))
+		{
+			LOG(WARNING) << "[SJSON] File '" << normalized
+			             << "' registered after engine enumerated '" << subdir
+			             << "'. Will not be loaded until next launch.";
+		}
+
+		LOG(INFO) << "Adding to SJSON files: " << absolute_path;
+		return true;
+	}
+
+	void scan_content_directory(const std::filesystem::path& content_base_path)
+	{
+		if (!std::filesystem::exists(content_base_path))
+		{
+			return;
+		}
+
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(
+		         content_base_path,
+		         std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
+		{
+			if (!entry.is_regular_file() || entry.path().extension() != ".sjson")
+			{
+				continue;
+			}
+
+			auto rel_path   = std::filesystem::relative(entry.path(), content_base_path);
+			std::string rel = (char*)rel_path.u8string().c_str();
+			std::string abs = (char*)entry.path().u8string().c_str();
+
+			std::string logical_rel = "Game/" + normalize_path(rel);
+			register_content_file(logical_rel, abs);
+		}
+	}
+
+	void scan_all_plugin_content_directories(const std::filesystem::path& plugins_data_path)
+	{
+		if (!std::filesystem::exists(plugins_data_path))
+		{
+			return;
+		}
+
+		for (const auto& mod_dir : std::filesystem::directory_iterator(
+		         plugins_data_path,
+		         std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
+		{
+			if (!mod_dir.is_directory())
+			{
+				continue;
+			}
+
+			auto sjson_dir = mod_dir.path() / SJSON_DATA_DIR_NAME;
+			if (std::filesystem::exists(sjson_dir) && std::filesystem::is_directory(sjson_dir))
+			{
+				scan_content_directory(sjson_dir);
+			}
+		}
+	}
+
+	void mark_directory_enumerated(const std::string& normalized_subdir, const std::string& extension)
+	{
+		std::unique_lock lock(g_overlay_mutex);
+		g_enumerated_directories.insert(big::string::to_lower(normalized_subdir) + "|" + big::string::to_lower(extension));
+	}
+
+	std::string lookup_overlay_path(const std::string& normalized_relpath)
+	{
+		std::shared_lock lock(g_overlay_mutex);
+		auto it = g_path_index.find(normalized_relpath);
+		if (it != g_path_index.end())
+		{
+			return it->second;
+		}
+		return "";
+	}
+} // namespace sjson_overlay

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -46,21 +46,20 @@ namespace sjson_overlay
 
 	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
 	{
-		// Canonical lowercase key for case-insensitive matching on Windows
-		std::string key = big::string::to_lower(normalize_path(logical_relpath));
+		std::string normalized = normalize_path(logical_relpath);
 
 		// Extract directory and extension
 		std::string subdir;
 		std::string filename;
-		auto last_slash = key.rfind('/');
+		auto last_slash = normalized.rfind('/');
 		if (last_slash != std::string::npos)
 		{
-			subdir   = key.substr(0, last_slash);
-			filename = key.substr(last_slash + 1);
+			subdir   = normalized.substr(0, last_slash);
+			filename = normalized.substr(last_slash + 1);
 		}
 		else
 		{
-			filename = key;
+			filename = normalized;
 		}
 
 		std::string extension;
@@ -70,15 +69,15 @@ namespace sjson_overlay
 			extension = filename.substr(dot_pos);
 		}
 
-		if (extension != ".sjson")
+		if (big::string::to_lower(extension) != ".sjson")
 		{
-			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << key;
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
 			return false;
 		}
 
 		if (!is_known_engine_directory(subdir))
 		{
-			LOG(WARNING) << "[SJSON] SJSON file '" << key
+			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
 			             << "' is in a directory not known to be scanned by the engine. "
 			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
 			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
@@ -86,19 +85,21 @@ namespace sjson_overlay
 
 		std::unique_lock lock(g_overlay_mutex);
 
-		if (g_path_index.count(key))
+		if (g_path_index.count(normalized))
 		{
-			LOG(WARNING) << "[SJSON] Duplicate: '" << key << "' already registered from '"
-			             << g_path_index[key] << "', ignoring '" << absolute_path << "'";
+			if (g_path_index[normalized] != absolute_path)
+			{
+				LOG(WARNING) << "[SJSON] File '" << normalized << "' already registered from '" << g_path_index[normalized] << "', ignoring '" << absolute_path << "'";
+			}
 			return false;
 		}
 
-		g_path_index[key] = absolute_path;
+		g_path_index[normalized] = absolute_path;
 
-		std::string enum_key = subdir + "|" + extension;
+		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
 		if (g_enumerated_directories.count(enum_key))
 		{
-			LOG(WARNING) << "[SJSON] File '" << key
+			LOG(WARNING) << "[SJSON] File '" << normalized
 			             << "' registered after engine enumerated '" << subdir
 			             << "'. Will not be loaded until next launch.";
 		}
@@ -165,7 +166,7 @@ namespace sjson_overlay
 	std::string lookup_overlay_path(const std::string& normalized_relpath)
 	{
 		std::shared_lock lock(g_overlay_mutex);
-		auto it = g_path_index.find(big::string::to_lower(normalized_relpath));
+		auto it = g_path_index.find(normalized_relpath);
 		if (it != g_path_index.end())
 		{
 			return it->second;

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -46,20 +46,21 @@ namespace sjson_overlay
 
 	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
 	{
-		std::string normalized = normalize_path(logical_relpath);
+		// Canonical lowercase key for case-insensitive matching on Windows
+		std::string key = big::string::to_lower(normalize_path(logical_relpath));
 
 		// Extract directory and extension
 		std::string subdir;
 		std::string filename;
-		auto last_slash = normalized.rfind('/');
+		auto last_slash = key.rfind('/');
 		if (last_slash != std::string::npos)
 		{
-			subdir   = normalized.substr(0, last_slash);
-			filename = normalized.substr(last_slash + 1);
+			subdir   = key.substr(0, last_slash);
+			filename = key.substr(last_slash + 1);
 		}
 		else
 		{
-			filename = normalized;
+			filename = key;
 		}
 
 		std::string extension;
@@ -69,15 +70,15 @@ namespace sjson_overlay
 			extension = filename.substr(dot_pos);
 		}
 
-		if (big::string::to_lower(extension) != ".sjson")
+		if (extension != ".sjson")
 		{
-			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << key;
 			return false;
 		}
 
 		if (!is_known_engine_directory(subdir))
 		{
-			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
+			LOG(WARNING) << "[SJSON] SJSON file '" << key
 			             << "' is in a directory not known to be scanned by the engine. "
 			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
 			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
@@ -85,17 +86,17 @@ namespace sjson_overlay
 
 		std::unique_lock lock(g_overlay_mutex);
 
-		if (g_path_index.count(normalized))
+		if (g_path_index.count(key))
 		{
 			return false;
 		}
 
-		g_path_index[normalized] = absolute_path;
+		g_path_index[key] = absolute_path;
 
-		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
+		std::string enum_key = subdir + "|" + extension;
 		if (g_enumerated_directories.count(enum_key))
 		{
-			LOG(WARNING) << "[SJSON] File '" << normalized
+			LOG(WARNING) << "[SJSON] File '" << key
 			             << "' registered after engine enumerated '" << subdir
 			             << "'. Will not be loaded until next launch.";
 		}
@@ -162,7 +163,7 @@ namespace sjson_overlay
 	std::string lookup_overlay_path(const std::string& normalized_relpath)
 	{
 		std::shared_lock lock(g_overlay_mutex);
-		auto it = g_path_index.find(normalized_relpath);
+		auto it = g_path_index.find(big::string::to_lower(normalized_relpath));
 		if (it != g_path_index.end())
 		{
 			return it->second;

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -88,6 +88,8 @@ namespace sjson_overlay
 
 		if (g_path_index.count(key))
 		{
+			LOG(WARNING) << "[SJSON] Duplicate: '" << key << "' already registered from '"
+			             << g_path_index[key] << "', ignoring '" << absolute_path << "'";
 			return false;
 		}
 

--- a/src/sjson_overlay.hpp
+++ b/src/sjson_overlay.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <filesystem>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace sjson_overlay
+{
+	// The canonical directory name for SJSON data overlays within each mod's plugins_data folder.
+	// Mods place .sjson files in plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/, Text/{lang}/, etc.
+	inline constexpr const char* SJSON_DATA_DIR_NAME = "Hell2Modding-SJSON";
+
+	// Known engine-scanned directories under Content/Game/ (lowercase, forward slashes).
+	// .sjson files outside these directories get a validation warning.
+	inline const std::vector<std::string> g_known_engine_directories = {
+	    "game",
+	    "game/animations",
+	    "game/gui",
+	    "game/obstacles",
+	    "game/projectiles",
+	    "game/units",
+	    "game/weapons",
+	};
+
+	// Known locale subdirectories under Game/Text/ (lowercase).
+	inline const std::vector<std::string> g_known_text_locales = {
+	    "de", "el", "en", "es", "fr", "it", "ja", "ko",
+	    "pl", "pt-br", "ru", "tr", "uk", "zh-cn", "zh-tw",
+	};
+
+	// Path index: logical_relpath (normalized, forward slashes) -> absolute_path
+	inline std::unordered_map<std::string, std::string> g_path_index;
+
+	// Tracks which (subdir, extension) pairs the engine has already enumerated
+	inline std::unordered_set<std::string> g_enumerated_directories;
+
+	inline std::shared_mutex g_overlay_mutex;
+
+	std::string normalize_path(const std::string& path);
+	bool is_known_engine_directory(const std::string& normalized_subdir);
+	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path);
+	void scan_content_directory(const std::filesystem::path& content_base_path);
+	void scan_all_plugin_content_directories(const std::filesystem::path& plugins_data_path);
+	void mark_directory_enumerated(const std::string& normalized_subdir, const std::string& extension);
+	std::string lookup_overlay_path(const std::string& normalized_relpath);
+} // namespace sjson_overlay


### PR DESCRIPTION
This allows mod authors to place `.sjson` files into `plugins_data/<mod-guid>/Hell2Modding-SJSON/*`, where the subdirectories in `Hell2Modding-SJSON` MUST match `Game/` directories in Hades II - such as `Animations`, `Text/en/` etc. 
This is due to the way the game loads these files in groups, and ensures that we don't run into any unexpected behaviour. 
A mod author can get the absolute path to the `Hell2Modding-SJSON` directory by using the new `_PLUGIN.sjson_data_path`.

Also supports runtime creation+registration in case files are only created in the `plugins_data` when the game runs, e.g. during a mod installation operation (required for Zagreus' Journey)