### PR TITLE
feat: discover and inject various file types from plugins_data

### DIFF
--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -21,6 +21,19 @@ namespace sgg
 	};
 } // namespace sgg
 
+extern std::unordered_map<std::string, std::string> additional_map_files;
+
+struct vo_file_registry
+{
+	std::unordered_map<std::string, std::string> fsb_files;
+	std::unordered_map<std::string, std::string> txt_files;
+};
+extern vo_file_registry additional_vo_files;
+
+extern std::unordered_map<std::string, std::string> additional_bik_files;
+extern std::shared_mutex g_plugin_files_mutex;
+extern int ends_with(const char* str, const char* suffix);
+
 namespace lua::hades::data
 {
 	static std::recursive_mutex g_load_packages_overrides_mutex;
@@ -479,7 +492,7 @@ namespace lua::hades::data
 
 		// Lua API: Function
 		// Table: data
-		// Name: register_content_file
+		// Name: register_sjson_file
 		// Param: absolute_path: string: The absolute filesystem path to a .sjson file inside a <SJSON_DATA_DIR_NAME> directory.
 		// Returns: boolean: true if registered successfully, false if the file is a duplicate, not a .sjson, or the path does not contain <SJSON_DATA_DIR_NAME>.
 		// Registers a .sjson file so the engine discovers and loads it as if it were in the game's `Content/Game/` directory.
@@ -487,13 +500,13 @@ namespace lua::hades::data
 		// For example, `plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/Foo.sjson` is loaded as `Content/Game/Animations/Foo.sjson`.
 		// At startup, Hell2Modding automatically scans every mod's <SJSON_DATA_DIR_NAME> directory and registers any .sjson files found.
 		// Use this function to dynamically register files created during the current session (e.g. a first-time install placing a file into plugins_data).
-		ns.set_function("register_content_file", [](const std::string& absolute_path) -> bool {
+		ns.set_function("register_sjson_file", [](const std::string& absolute_path) -> bool {
 			std::string normalized = sjson_overlay::normalize_path(absolute_path);
 			const std::string marker = std::string(sjson_overlay::SJSON_DATA_DIR_NAME) + "/";
 			auto pos = normalized.find(marker);
 			if (pos == std::string::npos)
 			{
-				LOG(WARNING) << "[SJSON] register_content_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
+				LOG(WARNING) << "[SJSON] register_sjson_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
 				return false;
 			}
 			// Convention: <SJSON_DATA_DIR_NAME> implicitly maps to Game/ in Content
@@ -530,6 +543,56 @@ namespace lua::hades::data
 			}
 			sjson_overlay::g_path_index[normalized] = absolute_path;
 			LOG(INFO) << "Adding file redirect: " << normalized << " -> " << absolute_path;
+			return true;
+		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: register_plugin_file
+		// Param: filename: string: The filename (e.g. "D_Boss01.map_text", "HadesBattleIdle.bik", "Zagreus.fsb")
+		// Param: absolute_path: string: The absolute filesystem path to the file
+		// Returns: boolean: true if registered, false if already registered or unsupported extension
+		// Registers a file for engine injection and redirect. Routes to the appropriate internal registry.
+		// Supported extensions: .map_text, .thing_bin, .bik, .bik_atlas, .fsb, .txt.
+		// SJSON files should use `register_sjson_file` instead.
+		ns.set_function("register_plugin_file", [](const std::string& filename, const std::string& absolute_path) -> bool {
+			std::unordered_map<std::string, std::string>* target = nullptr;
+			const char* label = nullptr;
+
+			if (ends_with(filename.c_str(), ".map_text") || ends_with(filename.c_str(), ".thing_bin"))
+			{
+				target = &additional_map_files;
+				label = "map";
+			}
+			else if (ends_with(filename.c_str(), ".bik") || ends_with(filename.c_str(), ".bik_atlas"))
+			{
+				target = &additional_bik_files;
+				label = "bik";
+			}
+			else if (ends_with(filename.c_str(), ".fsb"))
+			{
+				target = &additional_vo_files.fsb_files;
+				label = "VO (fsb)";
+			}
+			else if (ends_with(filename.c_str(), ".txt"))
+			{
+				target = &additional_vo_files.txt_files;
+				label = "VO (txt)";
+			}
+
+			if (!target)
+			{
+				LOG(WARNING) << "register_plugin_file: unsupported extension for '" << filename << "'";
+				return false;
+			}
+
+			std::unique_lock lock(g_plugin_files_mutex);
+			if (target->count(filename))
+			{
+				return false;
+			}
+			(*target)[filename] = absolute_path;
+			LOG(INFO) << "Adding to " << label << " files: " << absolute_path;
 			return true;
 		});
 

--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -1,6 +1,7 @@
 #include "data.hpp"
 
 #include "hades_ida.hpp"
+#include "sjson_overlay.hpp"
 
 #include <hades2/pdb_symbol_map.hpp>
 #include <hooks/hooking.hpp>
@@ -227,7 +228,29 @@ namespace lua::hades::data
 			{
 				std::scoped_lock l(big::lua_manager_extension::g_manager_mutex);
 
-				g_sjson_FileStream_to_filepath[g_current_file_stream] = output_;
+				// If the output was redirected to an SJSON overlay path, it won't match sjson.hook filters
+				// sjson.hook filters use Content/ paths, which we need to reconstruct
+				// The base path is the ResourceDirectory root (e.g. "C:\...\Content\Game\Animations"), and pathComponent is the filename
+				// We check if the output contains the overlay marker and fall back to the original path
+				std::string output_str = (char*)output_.u8string().c_str();
+				if (output_str.find(sjson_overlay::SJSON_DATA_DIR_NAME) != std::string::npos)
+				{
+					// Output was redirected to overlay - build the original Content/ path instead
+					char original_path[512];
+					strncpy(original_path, basePath, sizeof(original_path) - 1);
+					original_path[sizeof(original_path) - 1] = '\0';
+					size_t base_len = strlen(original_path);
+					if (base_len > 0 && original_path[base_len - 1] != '\\' && original_path[base_len - 1] != '/')
+					{
+						strncat(original_path, "\\", sizeof(original_path) - base_len - 1);
+					}
+					strncat(original_path, pathComponent, sizeof(original_path) - strlen(original_path) - 1);
+					g_sjson_FileStream_to_filepath[g_current_file_stream] = original_path;
+				}
+				else
+				{
+					g_sjson_FileStream_to_filepath[g_current_file_stream] = output_;
+				}
 			}
 		}
 	}
@@ -444,6 +467,49 @@ namespace lua::hades::data
 
 		ns.set_function("load_package_overrides_get", load_package_overrides_get);
 		ns.set_function("load_package_overrides_set", load_package_overrides_set);
+
+		// Lua API: Field
+		// Table: data
+		// Name: SJSON_DATA_DIR_NAME
+		// Value: "Hell2Modding-SJSON"
+		// The canonical directory name for the SJSON data overlay.
+		// Mods must place .sjson files in plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/, Text/{lang}/, etc.
+		// Hell2Modding scans this directory at startup and injects discovered .sjson files into the engine's loading pipeline.
+		ns["SJSON_DATA_DIR_NAME"] = sjson_overlay::SJSON_DATA_DIR_NAME;
+
+		// Lua API: Function
+		// Table: data
+		// Name: register_content_file
+		// Param: absolute_path: string: The absolute filesystem path to a .sjson file inside a <SJSON_DATA_DIR_NAME> directory.
+		// Returns: boolean: true if registered successfully, false if the file is a duplicate, not a .sjson, or the path does not contain <SJSON_DATA_DIR_NAME>.
+		// Registers a .sjson file so the engine discovers and loads it as if it were in the game's `Content/Game/` directory.
+		// The engine-relative path is inferred automatically: files inside `plugins_data/<mod>/<SJSON_DATA_DIR_NAME>/` map to `Content/Game/`.
+		// For example, `plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/Foo.sjson` is loaded as `Content/Game/Animations/Foo.sjson`.
+		// At startup, Hell2Modding automatically scans every mod's <SJSON_DATA_DIR_NAME> directory and registers any .sjson files found.
+		// Use this function to dynamically register files created during the current session (e.g. a first-time install placing a file into plugins_data).
+		ns.set_function("register_content_file", [](const std::string& absolute_path) -> bool {
+			std::string normalized = sjson_overlay::normalize_path(absolute_path);
+			const std::string marker = std::string(sjson_overlay::SJSON_DATA_DIR_NAME) + "/";
+			auto pos = normalized.find(marker);
+			if (pos == std::string::npos)
+			{
+				LOG(WARNING) << "[SJSON] register_content_file: aborting, path does not contain '" << sjson_overlay::SJSON_DATA_DIR_NAME << "/' directory: " << absolute_path;
+				return false;
+			}
+			// Convention: <SJSON_DATA_DIR_NAME> implicitly maps to Game/ in Content
+			std::string logical_relpath = "Game/" + normalized.substr(pos + marker.size());
+			return sjson_overlay::register_content_file(logical_relpath, absolute_path);
+		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: register_content_directory
+		// Param: absolute_base_path: string: Absolute path to a directory whose structure mirrors `Content/Game/` (e.g. containing `Animations/`, `Text/en/`, etc.)
+		// Scans the directory recursively and registers all .sjson files found. Each file's engine path is derived from its position in the directory tree.
+		// This is the same scan that Hell2Modding performs automatically at startup for `plugins_data/*/<SJSON_DATA_DIR_NAME>/`.
+		ns.set_function("register_content_directory", [](const std::string& absolute_base_path) {
+			sjson_overlay::scan_content_directory(std::filesystem::path(absolute_base_path));
+		});
 
 		state["sol.__h2m_LoadPackages__"] = state["LoadPackages"];
 		// Lua API: Function

--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -511,6 +511,28 @@ namespace lua::hades::data
 			sjson_overlay::scan_content_directory(std::filesystem::path(absolute_base_path));
 		});
 
+		// Lua API: Function
+		// Table: data
+		// Name: register_file_redirect
+		// Param: content_relative_path: string: The path relative to Content/, e.g. "Maps/D_Hub.map_text" or "Maps/bin/D_Hub.thing_bin"
+		// Param: absolute_path: string: The absolute filesystem path to the actual file
+		// Returns: boolean: true if registered, false if duplicate
+		// Registers a file redirect so the engine loads it from an external location instead of Content/.
+		// Unlike register_content_file (SJSON-only), this works for any file type that the engine loads via fsAppendPathComponent (maps, etc.).
+		// No directory convention is enforced - the caller provides both paths.
+		ns.set_function("register_file_redirect", [](const std::string& content_relative_path, const std::string& absolute_path) -> bool {
+			std::string normalized = sjson_overlay::normalize_path(content_relative_path);
+
+			std::unique_lock lock(sjson_overlay::g_overlay_mutex);
+			if (sjson_overlay::g_path_index.count(normalized))
+			{
+				return false;
+			}
+			sjson_overlay::g_path_index[normalized] = absolute_path;
+			LOG(INFO) << "Adding file redirect: " << normalized << " -> " << absolute_path;
+			return true;
+		});
+
 		state["sol.__h2m_LoadPackages__"] = state["LoadPackages"];
 		// Lua API: Function
 		// Table: game

--- a/src/lua_extensions/lua_module_ext.hpp
+++ b/src/lua_extensions/lua_module_ext.hpp
@@ -54,15 +54,15 @@ namespace big
 	private:
 		void set_sjson_data_path()
 		{
-			auto sjson_data_path = g_file_manager.get_project_folder("plugins_data").get_path() / m_info.m_guid / sjson_overlay::SJSON_DATA_DIR_NAME;
-			auto sjson_data_path_string = std::string(reinterpret_cast<const char*>(sjson_data_path.u8string().c_str()));
-
 			sol::table ns = m_env["_PLUGIN"];
 			if (ns.valid())
 			{
+				auto sjson_data_path = g_file_manager.get_project_folder("plugins_data").get_path() / m_info.m_guid / sjson_overlay::SJSON_DATA_DIR_NAME;
+				auto sjson_data_path_string = std::string(reinterpret_cast<const char*>(sjson_data_path.u8string().c_str()));
+				
 				// Lua API: Field
-				// Table: _PLUGIN
-				// Name: sjson_data_path
+				// Table: _ENV - Plugin Specific Global Table
+				// Field: _PLUGIN.sjson_data_path: string
 				// The absolute path to the plugin's SJSON data directory (plugins_data/<mod-guid>/Hell2Modding-SJSON/).
 				// Mod authors can use this to discover or create .sjson files at runtime.
 				ns["sjson_data_path"] = sjson_data_path_string;

--- a/src/lua_extensions/lua_module_ext.hpp
+++ b/src/lua_extensions/lua_module_ext.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "bindings/hades/inputs.hpp"
+#include "sjson_overlay.hpp"
 #include "lua/lua_module.hpp"
+
+#include <paths/paths.hpp>
 
 namespace big
 {
@@ -32,11 +35,13 @@ namespace big
 		lua_module_ext(const module_info& module_info, sol::environment& env) :
 		    lua_module(module_info, env)
 		{
+			set_sjson_data_path();
 		}
 
 		lua_module_ext(const module_info& module_info, sol::state_view& state) :
 		    lua_module(module_info, state)
 		{
+			set_sjson_data_path();
 		}
 
 		inline void cleanup() override
@@ -44,6 +49,19 @@ namespace big
 			lua_module::cleanup();
 
 			m_data_ext = {};
+		}
+
+	private:
+		void set_sjson_data_path()
+		{
+			auto sjson_data_path = g_file_manager.get_project_folder("plugins_data").get_path() / m_info.m_guid / sjson_overlay::SJSON_DATA_DIR_NAME;
+			auto sjson_data_path_string = std::string(reinterpret_cast<const char*>(sjson_data_path.u8string().c_str()));
+
+			sol::table ns = m_env["_PLUGIN"];
+			if (ns.valid())
+			{
+				ns["sjson_data_path"] = sjson_data_path_string;
+			}
 		}
 	};
 } // namespace big

--- a/src/lua_extensions/lua_module_ext.hpp
+++ b/src/lua_extensions/lua_module_ext.hpp
@@ -60,6 +60,11 @@ namespace big
 			sol::table ns = m_env["_PLUGIN"];
 			if (ns.valid())
 			{
+				// Lua API: Field
+				// Table: _PLUGIN
+				// Name: sjson_data_path
+				// The absolute path to the plugin's SJSON data directory (plugins_data/<mod-guid>/Hell2Modding-SJSON/).
+				// Mod authors can use this to discover or create .sjson files at runtime.
 				ns["sjson_data_path"] = sjson_data_path_string;
 			}
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1706,26 +1706,18 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 		}
 
 		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		std::string normalized_output = sjson_overlay::normalize_path(output);
+		std::string lower_output = big::string::to_lower(normalized_output);
+		auto content_pos = lower_output.rfind("content/");
+		if (content_pos != std::string::npos)
 		{
-			std::string normalized_output = sjson_overlay::normalize_path(output);
-			std::string lower_output = big::string::to_lower(normalized_output);
-			auto content_pos = lower_output.rfind("content/");
-			if (content_pos != std::string::npos)
+			std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
+			std::string redirect_abspath = sjson_overlay::lookup_overlay_path(logical_path);
+			if (!redirect_abspath.empty())
 			{
-				std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
-				std::string overlay_abspath = sjson_overlay::lookup_overlay_path(logical_path);
-				if (!overlay_abspath.empty())
-				{
-					if (overlay_abspath.size() < 512)
-					{
-						LOG(DEBUG) << "[SJSON] Redirecting '" << logical_path << "' -> '" << overlay_abspath << "'";
-						strcpy(output, overlay_abspath.c_str());
-					}
-					else
-					{
-						LOG(WARNING) << "[SJSON] Overlay path too long (>511 bytes), skipping: " << overlay_abspath;
-					}
-				}
+				LOG(DEBUG) << pathComponent << " | " << logical_path << " | " << redirect_abspath;
+
+				strcpy(output, redirect_abspath.c_str());
 			}
 		}
 	}
@@ -1815,7 +1807,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 
 		std::string normalized_subdir = sjson_overlay::normalize_path(subDirectory);
 
-		// Only process .sjson file enumerations
 		if (ext_clean != ".sjson")
 		{
 			return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1717,7 +1717,8 @@ static void* hook_OpenBinkUtf8(char* filename, unsigned int flags)
 		auto it = additional_bik_files.find(bik_filename);
 		if (it != additional_bik_files.end() && ends_with(bik_filename, ".bik"))
 		{
-			LOG(DEBUG) << filename << " | " << it->first << " | " << it->second;
+			// Bink files are requested again on every use, this clutters the log
+			// LOG(DEBUG) << filename << " | " << it->first << " | " << it->second;
 
 			void* result = g_BinkOpen(it->second.c_str(), flags);
 			if (result)
@@ -1814,7 +1815,8 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 			auto it = additional_bik_files.find(pathComponent);
 			if (it != additional_bik_files.end())
 			{
-				LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
+				// Bink files are requested again on every use, this clutters the log
+				// LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
 
 				strcpy(output, it->second.c_str());
 				return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1506,7 +1506,7 @@ static void hook_disable_f10_launch(void *bugInfo)
 	}
 }
 
-static int ends_with(const char *str, const char *suffix)
+int ends_with(const char *str, const char *suffix)
 {
 	if (!str || !suffix)
 	{
@@ -1676,6 +1676,11 @@ struct vo_file_registry
 
 vo_file_registry additional_vo_files;
 
+std::unordered_map<std::string, std::string> additional_bik_files;
+
+// Guards runtime writes (register_plugin_file from Lua) against concurrent reads in hooks.
+std::shared_mutex g_plugin_files_mutex;
+
 // Simple glob match supporting a single '*' wildcard (e.g. "F_*.map_text")
 static bool glob_match(const std::string& pattern, const std::string& str)
 {
@@ -1692,6 +1697,39 @@ static bool glob_match(const std::string& pattern, const std::string& str)
 	    && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+// Hook for Bink video loading: OpenBinkUtf8 internally strips the directory from the path and calls
+// BinkOpen with just the filename after SetCurrentDirectoryW. This doesn't work for cross-drive redirects.
+// Instead, we resolve BinkOpen's address from bink2w64.dll and call it directly with the absolute path.
+static void* (*g_BinkOpen)(const char* filename, unsigned int flags) = nullptr;
+
+static void* hook_OpenBinkUtf8(char* filename, unsigned int flags)
+{
+	if (filename && g_BinkOpen)
+	{
+		const char* bik_filename = strrchr(filename, '/');
+		if (!bik_filename)
+		{
+			bik_filename = strrchr(filename, '\\');
+		}
+		bik_filename = bik_filename ? bik_filename + 1 : filename;
+
+		std::shared_lock lock(g_plugin_files_mutex);
+		auto it = additional_bik_files.find(bik_filename);
+		if (it != additional_bik_files.end() && ends_with(bik_filename, ".bik"))
+		{
+			LOG(DEBUG) << filename << " | " << it->first << " | " << it->second;
+
+			void* result = g_BinkOpen(it->second.c_str(), flags);
+			if (result)
+			{
+				return result;
+			}
+		}
+	}
+
+	return big::g_hooking->get_original<hook_OpenBinkUtf8>()(filename, flags);
+}
+
 //static std::string g_current_custom_package_stem;
 
 static void hook_fsAppendPathComponent(const char *basePath, const char *pathComponent, char *output /*size: 512*/)
@@ -1702,36 +1740,43 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 
 	if (strlen(pathComponent) > 0)
 	{
-		for (const auto &[filename, full_file_path] : additional_package_files)
 		{
-			if (strstr(pathComponent, filename.c_str()) && extension_matches(pathComponent, filename.c_str()))
+			std::shared_lock lock(g_plugin_files_mutex);
+			for (const auto &[filename, full_file_path] : additional_package_files)
 			{
-				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
-				//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
-				strcpy(output, full_file_path.c_str());
-				break;
-			}
-			else if (strcmp(filename.c_str(), pathComponent) == 0 && extension_matches(pathComponent, filename.c_str()))
-			{
-				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
-				//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
-				strcpy(output, full_file_path.c_str());
-				break;
-			}
-		}
-
-		for (const auto &[filename, full_file_path] : additional_granny_files)
-		{
-			if (strstr(pathComponent, filename.c_str()))
-			{
-				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
-
-				strcpy(output, full_file_path.c_str());
-				break;
+				if (strstr(pathComponent, filename.c_str()) && extension_matches(pathComponent, filename.c_str()))
+				{
+					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
+					//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
+					strcpy(output, full_file_path.c_str());
+					break;
+				}
+				else if (strcmp(filename.c_str(), pathComponent) == 0 && extension_matches(pathComponent, filename.c_str()))
+				{
+					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
+					//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
+					strcpy(output, full_file_path.c_str());
+					break;
+				}
 			}
 		}
 
 		{
+			std::shared_lock lock(g_plugin_files_mutex);
+			for (const auto &[filename, full_file_path] : additional_granny_files)
+			{
+				if (strstr(pathComponent, filename.c_str()))
+				{
+					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
+
+					strcpy(output, full_file_path.c_str());
+					break;
+				}
+			}
+		}
+
+		{
+			std::shared_lock lock(g_plugin_files_mutex);
 			auto it = additional_map_files.find(pathComponent);
 			if (it != additional_map_files.end())
 			{
@@ -1743,6 +1788,7 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 
 		// VO files: pathComponent includes subdir prefix (e.g. "VO\Zagreus.fsb"), match by filename
 		{
+			std::shared_lock lock(g_plugin_files_mutex);
 			const char* vo_filename = strrchr(pathComponent, '\\');
 			if (!vo_filename)
 			{
@@ -1767,6 +1813,19 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 					LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
 					strcpy(output, it->second.c_str());
 				}
+			}
+		}
+
+		// Bik files: match by filename for both .bik_atlas (engine I/O) and .bik (path stored in BinkFile::mFile via ReadBink)
+		{
+			std::shared_lock lock(g_plugin_files_mutex);
+			auto it = additional_bik_files.find(pathComponent);
+			if (it != additional_bik_files.end())
+			{
+				LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
+
+				strcpy(output, it->second.c_str());
+				return;
 			}
 		}
 
@@ -1829,28 +1888,31 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 	}
 
 	bool is_pkg_manifest_only = has_pkg_manifest && !has_pkg;
-	if (is_pkg_manifest_only)
 	{
-		for (const auto &[filename, full_file_path] : additional_package_files)
+		std::shared_lock lock(g_plugin_files_mutex);
+		if (is_pkg_manifest_only)
 		{
-			if (ends_with(filename.c_str(), ".pkg_manifest"))
+			for (const auto &[filename, full_file_path] : additional_package_files)
+			{
+				if (ends_with(filename.c_str(), ".pkg_manifest"))
+				{
+					out->push_back(filename.c_str());
+				}
+			}
+		}
+		else if (has_pkg && has_pkg_manifest)
+		{
+			for (const auto &[filename, full_file_path] : additional_package_files)
 			{
 				out->push_back(filename.c_str());
 			}
 		}
-	}
-	else if (has_pkg && has_pkg_manifest)
-	{
-		for (const auto &[filename, full_file_path] : additional_package_files)
+		else if (has_gpk)
 		{
-			out->push_back(filename.c_str());
-		}
-	}
-	else if (has_gpk)
-	{
-		for (const auto &[filename, full_file_path] : additional_granny_files)
-		{
-			out->push_back(filename.c_str());
+			for (const auto &[filename, full_file_path] : additional_granny_files)
+			{
+				out->push_back(filename.c_str());
+			}
 		}
 	}
 
@@ -1868,6 +1930,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 				existing.insert(f.c_str());
 			}
 
+			std::shared_lock lock(g_plugin_files_mutex);
 			for (const auto& [filename, filepath] : additional_map_files)
 			{
 				if (ends_with(filename.c_str(), ".map_text")
@@ -1895,6 +1958,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 				existing.insert(f.c_str());
 			}
 
+			std::shared_lock lock(g_plugin_files_mutex);
 			for (const auto& [filename, filepath] : additional_vo_files.fsb_files)
 			{
 
@@ -1905,6 +1969,31 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 				{
 					out->push_back(entry.c_str());
 					existing.insert(entry);
+				}
+			}
+		}
+	}
+
+	// Bik atlas injection: inject additional .bik_atlas files when engine enumerates movie manifests
+	// The engine scans Content/Movies/{resolution}/ with extension "*.bik_atlas"
+	if (extension)
+	{
+		const char* ext_as_char_bik = reinterpret_cast<const char*>(extension);
+		if (ext_as_char_bik && strstr(ext_as_char_bik, ".bik_atlas"))
+		{
+			std::unordered_set<std::string> existing;
+			for (const auto& f : *out)
+			{
+				existing.insert(f.c_str());
+			}
+
+			std::shared_lock lock(g_plugin_files_mutex);
+			for (const auto& [filename, filepath] : additional_bik_files)
+			{
+				if (ends_with(filename.c_str(), ".bik_atlas") && existing.find(filename) == existing.end())
+				{
+					out->push_back(filename.c_str());
+					existing.insert(filename);
 				}
 			}
 		}
@@ -2843,6 +2932,38 @@ extern "C" __declspec(dllexport) void my_main()
 	}
 
 	{
+		static auto ptr = big::hades2_symbol_to_address["sgg::OpenBinkUtf8"];
+		if (ptr)
+		{
+			static auto ptr_func = ptr;
+
+			static auto hook_ = hooking::detour_hook_helper::add_queue<hook_OpenBinkUtf8>(
+			    "OpenBinkUtf8 for bik file redirect",
+			    ptr_func);
+
+			// Resolve BinkOpen from the Bink SDK DLL so we can call it directly with absolute paths
+			HMODULE binkModule = GetModuleHandleA("bink2w64.dll");
+			if (binkModule)
+			{
+				g_BinkOpen = reinterpret_cast<decltype(g_BinkOpen)>(GetProcAddress(binkModule, "BinkOpen"));
+			}
+
+			if (g_BinkOpen)
+			{
+				LOG(INFO) << "Resolved BinkOpen from Bink SDK DLL";
+			}
+			else
+			{
+				LOG(WARNING) << "Could not resolve BinkOpen, .bik file redirect will fall through to OpenBinkUtf8";
+			}
+		}
+		else
+		{
+			LOG(WARNING) << "sgg::OpenBinkUtf8 symbol not found, .bik file redirect will not work";
+		}
+	}
+
+	{
 		static auto ptr = big::hades2_symbol_to_address["sgg::Obstacle::IsObscuring"];
 		if (ptr)
 		{
@@ -2936,6 +3057,13 @@ extern "C" __declspec(dllexport) void my_main()
 
 			LOG(INFO) << "Adding to VO files: " << (char *)entry.path().u8string().c_str();
 		}
+		else if (entry.path().extension() == ".bik" || entry.path().extension() == ".bik_atlas")
+		{
+			additional_bik_files.emplace((char *)entry.path().filename().u8string().c_str(),
+			                             (char *)entry.path().u8string().c_str());
+
+			LOG(INFO) << "Adding to bik files: " << (char *)entry.path().u8string().c_str();
+		}
 	}
 
 	// Register .txt companions for each discovered .fsb.
@@ -2994,6 +3122,7 @@ extern "C" __declspec(dllexport) void my_main()
 	validate_file_pairs(additional_package_files, ".pkg", additional_package_files, ".pkg_manifest");
 	validate_file_pairs(additional_map_files, ".map_text", additional_map_files, ".thing_bin");
 	validate_file_pairs(additional_vo_files.fsb_files, ".fsb", additional_vo_files.txt_files, ".txt");
+	validate_file_pairs(additional_bik_files, ".bik", additional_bik_files, ".bik_atlas");
 
 	// Scan for SJSON overlay files (plugins_data/*/<SJSON_DATA_DIR_NAME>/)
 	sjson_overlay::scan_all_plugin_content_directories(g_file_manager.get_project_folder("plugins_data").get_path());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1821,9 +1821,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			return;
 		}
 
-		// Mark this directory as enumerated so late registrations get a warning
-		sjson_overlay::mark_directory_enumerated(normalized_subdir, ext_clean);
-
 		// Determine the engine's target directory relative to Content/Game/ so we can match overlay files.
 		// resolved_base_dir is the physical path the engine is scanning (e.g. "C:/.../Content/Game/Animations").
 		// We extract the part after "Content/Game/" to get e.g. "Animations".
@@ -1852,6 +1849,9 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 				full_engine_subdir = normalized_subdir;
 			}
 		}
+
+		// Mark using the full logical directory (game/<subdir>) so it matches the keys used by register_content_file for late-registration warnings
+		sjson_overlay::mark_directory_enumerated("game/" + full_engine_subdir, ext_clean);
 
 		// Match overlay files whose directory matches the engine's target
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1666,6 +1666,24 @@ std::unordered_map<std::string, std::string> additional_package_files;
 
 std::unordered_map<std::string, std::string> additional_granny_files;
 
+std::unordered_map<std::string, std::string> additional_map_files;
+
+// Simple glob match supporting a single '*' wildcard (e.g. "F_*.map_text")
+static bool glob_match(const std::string& pattern, const std::string& str)
+{
+	auto star = pattern.find('*');
+	if (star == std::string::npos)
+	{
+		return pattern == str;
+	}
+
+	auto prefix = pattern.substr(0, star);
+	auto suffix = pattern.substr(star + 1);
+	return str.size() >= prefix.size() + suffix.size()
+	    && str.compare(0, prefix.size(), prefix) == 0
+	    && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 //static std::string g_current_custom_package_stem;
 
 static void hook_fsAppendPathComponent_packages(const char *basePath, const char *pathComponent, char *output /*size: 512*/)
@@ -1705,27 +1723,30 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 			}
 		}
 
-		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		for (const auto &[filename, full_file_path] : additional_map_files)
 		{
-			std::string normalized_output = sjson_overlay::normalize_path(output);
-			std::string lower_output = big::string::to_lower(normalized_output);
-			auto content_pos = lower_output.rfind("content/");
-			if (content_pos != std::string::npos)
+			if (strcmp(filename.c_str(), pathComponent) == 0)
 			{
-				std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
-				std::string overlay_abspath = sjson_overlay::lookup_overlay_path(logical_path);
-				if (!overlay_abspath.empty())
-				{
-					if (overlay_abspath.size() < 512)
-					{
-						LOG(DEBUG) << "[SJSON] Redirecting '" << logical_path << "' -> '" << overlay_abspath << "'";
-						strcpy(output, overlay_abspath.c_str());
-					}
-					else
-					{
-						LOG(WARNING) << "[SJSON] Overlay path too long (>511 bytes), skipping: " << overlay_abspath;
-					}
-				}
+				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
+
+				strcpy(output, full_file_path.c_str());
+				break;
+			}
+		}
+
+		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		std::string normalized_output = sjson_overlay::normalize_path(output);
+		std::string lower_output = big::string::to_lower(normalized_output);
+		auto content_pos = lower_output.rfind("content/");
+		if (content_pos != std::string::npos)
+		{
+			std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
+			std::string redirect_abspath = sjson_overlay::lookup_overlay_path(logical_path);
+			if (!redirect_abspath.empty())
+			{
+				LOG(DEBUG) << pathComponent << " | " << logical_path << " | " << redirect_abspath;
+
+				strcpy(output, redirect_abspath.c_str());
 			}
 		}
 	}
@@ -1797,6 +1818,33 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 		}
 	}
 
+	// Map file injection: inject additional map files when engine enumerates .map_text files
+	// The engine uses glob patterns (e.g. "X_*.map_text", "RoomOpening.map_text") to find maps per MapGroup
+	if (extension)
+	{
+		const char* ext_as_char_maps = reinterpret_cast<const char*>(extension);
+		if (ext_as_char_maps && strstr(ext_as_char_maps, ".map_text"))
+		{
+			std::string pattern(ext_as_char_maps);
+			std::unordered_set<std::string> existing;
+			for (const auto& f : *out)
+			{
+				existing.insert(f.c_str());
+			}
+
+			for (const auto& [filename, filepath] : additional_map_files)
+			{
+				if (ends_with(filename.c_str(), ".map_text")
+				    && glob_match(pattern, filename)
+				    && existing.find(filename) == existing.end())
+				{
+					out->push_back(filename.c_str());
+					existing.insert(filename);
+				}
+			}
+		}
+	}
+
 	// SJSON overlay: inject additional .sjson files into the engine's enumeration
 	if (subDirectory && extension)
 	{
@@ -1815,7 +1863,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 
 		std::string normalized_subdir = sjson_overlay::normalize_path(subDirectory);
 
-		// Only process .sjson file enumerations
 		if (ext_clean != ".sjson")
 		{
 			return;
@@ -2810,6 +2857,13 @@ extern "C" __declspec(dllexport) void my_main()
 			                                (char *)entry.path().u8string().c_str());
 
 			LOG(INFO) << "Adding to granny files: " << (char *)entry.path().u8string().c_str();
+		}
+		else if (entry.path().extension() == ".map_text" || entry.path().extension() == ".thing_bin")
+		{
+			additional_map_files.emplace((char *)entry.path().filename().u8string().c_str(),
+			                             (char *)entry.path().u8string().c_str());
+
+			LOG(INFO) << "Adding to map files: " << (char *)entry.path().u8string().c_str();
 		}
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1910,7 +1910,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 
 	// Map file injection: inject additional map files when engine enumerates .map_text files
 	// The engine uses glob patterns (e.g. "X_*.map_text", "RoomOpening.map_text") to find maps per MapGroup
-	if (extension && strstr(extension, ".map_text"))
+	if (extension && ends_with(extension, ".map_text"))
 	{
 		std::string pattern(extension);
 		std::unordered_set<std::string> existing;
@@ -1934,7 +1934,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 
 	// VO file injection: inject additional .fsb files when engine enumerates voiceover files
 	// The engine scans Audio/Desktop/ with subDirectory="VO" and extension="*.fsb"
-	if (extension && strstr(extension, ".fsb"))
+	if (extension && ends_with(extension, ".fsb"))
 	{
 		std::string subdir_str = subDirectory ? subDirectory : "";
 		std::unordered_set<std::string> existing;
@@ -1960,7 +1960,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 
 	// Bik atlas injection: inject additional .bik_atlas files when engine enumerates movie manifests
 	// The engine scans Content/Movies/{resolution}/ with extension "*.bik_atlas"
-	if (extension && strstr(extension, ".bik_atlas"))
+	if (extension && ends_with(extension, ".bik_atlas"))
 	{
 		std::unordered_set<std::string> existing;
 		for (const auto& f : *out)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1864,13 +1864,13 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
 			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
 			{
-				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
+				// relpath keys are lowercase, e.g. "game/animations/foo.sjson" - strip "game/" prefix
 				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
-				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "game/")
 				{
 					continue;
 				}
-				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "animations/foo.sjson"
 
 				// Check extension
 				auto dot_pos = game_relative.rfind('.');

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1747,14 +1747,6 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 				if (strstr(pathComponent, filename.c_str()) && extension_matches(pathComponent, filename.c_str()))
 				{
 					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
-					//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
-					strcpy(output, full_file_path.c_str());
-					break;
-				}
-				else if (strcmp(filename.c_str(), pathComponent) == 0 && extension_matches(pathComponent, filename.c_str()))
-				{
-					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
-					//g_current_custom_package_stem = (char *)std::filesystem::path(filename).stem().u8string().c_str();
 					strcpy(output, full_file_path.c_str());
 					break;
 				}
@@ -1847,7 +1839,7 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 	}
 }
 
-static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirectory, wchar_t *extension, eastl::vector<eastl::string> *out)
+static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirectory, const char *extension, eastl::vector<eastl::string> *out)
 {
 	big::g_hooking->get_original<hook_fsGetFilesWithExtension>()(resourceDir, subDirectory, extension, out);
 
@@ -1918,83 +1910,71 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 
 	// Map file injection: inject additional map files when engine enumerates .map_text files
 	// The engine uses glob patterns (e.g. "X_*.map_text", "RoomOpening.map_text") to find maps per MapGroup
-	if (extension)
+	if (extension && strstr(extension, ".map_text"))
 	{
-		const char* ext_as_char_maps = reinterpret_cast<const char*>(extension);
-		if (ext_as_char_maps && strstr(ext_as_char_maps, ".map_text"))
+		std::string pattern(extension);
+		std::unordered_set<std::string> existing;
+		for (const auto& f : *out)
 		{
-			std::string pattern(ext_as_char_maps);
-			std::unordered_set<std::string> existing;
-			for (const auto& f : *out)
-			{
-				existing.insert(f.c_str());
-			}
+			existing.insert(f.c_str());
+		}
 
-			std::shared_lock lock(g_plugin_files_mutex);
-			for (const auto& [filename, filepath] : additional_map_files)
+		std::shared_lock lock(g_plugin_files_mutex);
+		for (const auto& [filename, filepath] : additional_map_files)
+		{
+			if (ends_with(filename.c_str(), ".map_text")
+			    && glob_match(pattern, filename)
+			    && existing.find(filename) == existing.end())
 			{
-				if (ends_with(filename.c_str(), ".map_text")
-				    && glob_match(pattern, filename)
-				    && existing.find(filename) == existing.end())
-				{
-					out->push_back(filename.c_str());
-					existing.insert(filename);
-				}
+				out->push_back(filename.c_str());
+				existing.insert(filename);
 			}
 		}
 	}
 
 	// VO file injection: inject additional .fsb files when engine enumerates voiceover files
 	// The engine scans Audio/Desktop/ with subDirectory="VO" and extension="*.fsb"
-	if (extension)
+	if (extension && strstr(extension, ".fsb"))
 	{
-		const char* ext_as_char_vo = reinterpret_cast<const char*>(extension);
-		if (ext_as_char_vo && strstr(ext_as_char_vo, ".fsb"))
+		std::string subdir_str = subDirectory ? subDirectory : "";
+		std::unordered_set<std::string> existing;
+		for (const auto& f : *out)
 		{
-			std::string subdir_str = subDirectory ? subDirectory : "";
-			std::unordered_set<std::string> existing;
-			for (const auto& f : *out)
+			existing.insert(f.c_str());
+		}
+
+		std::shared_lock lock(g_plugin_files_mutex);
+		for (const auto& [filename, filepath] : additional_vo_files.fsb_files)
+		{
+
+			// Build entry with subdir prefix if present (engine expects "VO\\filename.fsb")
+			std::string entry = subdir_str.empty() ? filename : subdir_str + "\\" + filename;
+
+			if (existing.find(entry) == existing.end())
 			{
-				existing.insert(f.c_str());
-			}
-
-			std::shared_lock lock(g_plugin_files_mutex);
-			for (const auto& [filename, filepath] : additional_vo_files.fsb_files)
-			{
-
-				// Build entry with subdir prefix if present (engine expects "VO\\filename.fsb")
-				std::string entry = subdir_str.empty() ? filename : subdir_str + "\\" + filename;
-
-				if (existing.find(entry) == existing.end())
-				{
-					out->push_back(entry.c_str());
-					existing.insert(entry);
-				}
+				out->push_back(entry.c_str());
+				existing.insert(entry);
 			}
 		}
 	}
 
 	// Bik atlas injection: inject additional .bik_atlas files when engine enumerates movie manifests
 	// The engine scans Content/Movies/{resolution}/ with extension "*.bik_atlas"
-	if (extension)
+	if (extension && strstr(extension, ".bik_atlas"))
 	{
-		const char* ext_as_char_bik = reinterpret_cast<const char*>(extension);
-		if (ext_as_char_bik && strstr(ext_as_char_bik, ".bik_atlas"))
+		std::unordered_set<std::string> existing;
+		for (const auto& f : *out)
 		{
-			std::unordered_set<std::string> existing;
-			for (const auto& f : *out)
-			{
-				existing.insert(f.c_str());
-			}
+			existing.insert(f.c_str());
+		}
 
-			std::shared_lock lock(g_plugin_files_mutex);
-			for (const auto& [filename, filepath] : additional_bik_files)
+		std::shared_lock lock(g_plugin_files_mutex);
+		for (const auto& [filename, filepath] : additional_bik_files)
+		{
+			if (ends_with(filename.c_str(), ".bik_atlas") && existing.find(filename) == existing.end())
 			{
-				if (ends_with(filename.c_str(), ".bik_atlas") && existing.find(filename) == existing.end())
-				{
-					out->push_back(filename.c_str());
-					existing.insert(filename);
-				}
+				out->push_back(filename.c_str());
+				existing.insert(filename);
 			}
 		}
 	}
@@ -2002,14 +1982,12 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 	// SJSON overlay: inject additional .sjson files into the engine's enumeration
 	if (subDirectory && extension)
 	{
-		// The extension parameter is char* despite the wchar_t* in the hook signature
-		const char* ext_as_char = reinterpret_cast<const char*>(extension);
-		if (!ext_as_char || ext_as_char[0] == '\0')
+		if (extension[0] == '\0')
 		{
 			return;
 		}
 
-		std::string ext_clean(ext_as_char);
+		std::string ext_clean(extension);
 		if (ext_clean.size() > 1 && ext_clean[0] == '*')
 		{
 			ext_clean = ext_clean.substr(1);
@@ -2067,7 +2045,7 @@ static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirec
 			{
 				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
 				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
-				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
+				if (!normalized_relpath.starts_with("Game/"))
 				{
 					continue;
 				}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1744,7 +1744,7 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 			std::shared_lock lock(g_plugin_files_mutex);
 			for (const auto &[filename, full_file_path] : additional_package_files)
 			{
-				if (strstr(pathComponent, filename.c_str()) && extension_matches(pathComponent, filename.c_str()))
+				if (strcmp(pathComponent, filename.c_str()) == 0)
 				{
 					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
 					strcpy(output, full_file_path.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1758,7 +1758,7 @@ static void hook_fsAppendPathComponent(const char *basePath, const char *pathCom
 			std::shared_lock lock(g_plugin_files_mutex);
 			for (const auto &[filename, full_file_path] : additional_granny_files)
 			{
-				if (strstr(pathComponent, filename.c_str()))
+				if (strcmp(pathComponent, filename.c_str()) == 0)
 				{
 					LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1864,13 +1864,13 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
 			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
 			{
-				// relpath keys are lowercase, e.g. "game/animations/foo.sjson" - strip "game/" prefix
+				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
 				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
-				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "game/")
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
 				{
 					continue;
 				}
-				std::string game_relative = normalized_relpath.substr(5); // e.g. "animations/foo.sjson"
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
 
 				// Check extension
 				auto dot_pos = game_relative.rfind('.');

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "threads/thread_pool.hpp"
 #include "threads/util.hpp"
 #include "version.hpp"
+#include "sjson_overlay.hpp"
 
 #include <DbgHelp.h>
 #include <hades2/pdb_symbol_map.hpp>
@@ -1703,12 +1704,51 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 				break;
 			}
 		}
+
+		// SJSON overlay: Redirect file paths to the mod's SJSON data directory.
+		{
+			std::string normalized_output = sjson_overlay::normalize_path(output);
+			std::string lower_output = big::string::to_lower(normalized_output);
+			auto content_pos = lower_output.rfind("content/");
+			if (content_pos != std::string::npos)
+			{
+				std::string logical_path = normalized_output.substr(content_pos + 8); // len("content/") = 8
+				std::string overlay_abspath = sjson_overlay::lookup_overlay_path(logical_path);
+				if (!overlay_abspath.empty())
+				{
+					if (overlay_abspath.size() < 512)
+					{
+						LOG(DEBUG) << "[SJSON] Redirecting '" << logical_path << "' -> '" << overlay_abspath << "'";
+						strcpy(output, overlay_abspath.c_str());
+					}
+					else
+					{
+						LOG(WARNING) << "[SJSON] Overlay path too long (>511 bytes), skipping: " << overlay_abspath;
+					}
+				}
+			}
+		}
 	}
 }
 
 static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char *subDirectory, wchar_t *extension, eastl::vector<eastl::string> *out)
 {
 	big::g_hooking->get_original<hook_fsGetFilesWithExtension_packages>()(resourceDir, subDirectory, extension, out);
+
+	// Resolve the ResourceDirectory to its physical path so we can match the correct sjson files (and not include those that belong to a different group)
+	std::string resolved_base_dir;
+	{
+		static auto fsGetResourceDirectory_ptr = big::hades2_symbol_to_address["fsGetResourceDirectory"];
+		if (fsGetResourceDirectory_ptr)
+		{
+			static auto fsGetResourceDirectory = fsGetResourceDirectory_ptr.as_func<const char*(PVOID)>();
+			const char* base = fsGetResourceDirectory(resourceDir);
+			if (base)
+			{
+				resolved_base_dir = sjson_overlay::normalize_path(base);
+			}
+		}
+	}
 
 	bool has_pkg_manifest = false;
 	bool has_pkg          = false;
@@ -1754,6 +1794,133 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 		for (const auto &[filename, full_file_path] : additional_granny_files)
 		{
 			out->push_back(filename.c_str());
+		}
+	}
+
+	// SJSON overlay: inject additional .sjson files into the engine's enumeration
+	if (subDirectory && extension)
+	{
+		// The extension parameter is char* despite the wchar_t* in the hook signature
+		const char* ext_as_char = reinterpret_cast<const char*>(extension);
+		if (!ext_as_char || ext_as_char[0] == '\0')
+		{
+			return;
+		}
+
+		std::string ext_clean(ext_as_char);
+		if (ext_clean.size() > 1 && ext_clean[0] == '*')
+		{
+			ext_clean = ext_clean.substr(1);
+		}
+
+		std::string normalized_subdir = sjson_overlay::normalize_path(subDirectory);
+
+		// Only process .sjson file enumerations
+		if (ext_clean != ".sjson")
+		{
+			return;
+		}
+
+		// Mark this directory as enumerated so late registrations get a warning
+		sjson_overlay::mark_directory_enumerated(normalized_subdir, ext_clean);
+
+		// Determine the engine's target directory relative to Content/Game/ so we can match overlay files.
+		// resolved_base_dir is the physical path the engine is scanning (e.g. "C:/.../Content/Game/Animations").
+		// We extract the part after "Content/Game/" to get e.g. "Animations".
+		std::string engine_game_subdir;
+		if (!resolved_base_dir.empty())
+		{
+			std::string lower_base = big::string::to_lower(resolved_base_dir);
+
+			auto game_pos = lower_base.find("content/game/");
+			if (game_pos != std::string::npos)
+			{
+				engine_game_subdir = resolved_base_dir.substr(game_pos + 13);
+			}
+		}
+
+		// Combine engine base subdir with the subDirectory parameter for nested scans (e.g. Text/{lang})
+		std::string full_engine_subdir = engine_game_subdir;
+		if (!normalized_subdir.empty())
+		{
+			if (!full_engine_subdir.empty())
+			{
+				full_engine_subdir += "/" + normalized_subdir;
+			}
+			else
+			{
+				full_engine_subdir = normalized_subdir;
+			}
+		}
+
+		// Match overlay files whose directory matches the engine's target
+		{
+			std::unordered_set<std::string> existing;
+			for (const auto& existing_file : *out)
+			{
+				existing.insert(existing_file.c_str());
+			}
+
+			std::shared_lock lock(sjson_overlay::g_overlay_mutex);
+			for (const auto& [relpath, abspath] : sjson_overlay::g_path_index)
+			{
+				// relpath is like "Game/Animations/Foo.sjson" - strip "Game/" prefix
+				std::string normalized_relpath = sjson_overlay::normalize_path(relpath);
+				if (normalized_relpath.size() <= 5 || normalized_relpath.substr(0, 5) != "Game/")
+				{
+					continue;
+				}
+				std::string game_relative = normalized_relpath.substr(5); // e.g. "Animations/Foo.sjson"
+
+				// Check extension
+				auto dot_pos = game_relative.rfind('.');
+				if (dot_pos == std::string::npos || game_relative.substr(dot_pos) != ext_clean)
+				{
+					continue;
+				}
+
+				// Extract file's directory and filename
+				auto slash_pos = game_relative.rfind('/');
+				std::string file_subdir;
+				std::string filename;
+				if (slash_pos != std::string::npos)
+				{
+					file_subdir = game_relative.substr(0, slash_pos);
+					filename = game_relative.substr(slash_pos + 1);
+				}
+				else
+				{
+					file_subdir = "";
+					filename = game_relative;
+				}
+
+				// Case-insensitive directory comparison
+				std::string lower_file_subdir = big::string::to_lower(file_subdir);
+				std::string lower_full_engine_subdir = big::string::to_lower(full_engine_subdir);
+
+				if (lower_file_subdir != lower_full_engine_subdir)
+				{
+					continue;
+				}
+
+				// Build the entry in the format the engine expects
+				std::string entry_to_inject;
+				if (!normalized_subdir.empty())
+				{
+					entry_to_inject = normalized_subdir + "\\" + filename;
+				}
+				else
+				{
+					entry_to_inject = filename;
+				}
+
+				if (existing.find(entry_to_inject) == existing.end())
+				{
+					out->push_back(entry_to_inject.c_str());
+					existing.insert(entry_to_inject);
+					LOG(DEBUG) << "[SJSON] Injected '" << entry_to_inject << "' into " << full_engine_subdir;
+				}
+			}
 		}
 	}
 }
@@ -2645,6 +2812,9 @@ extern "C" __declspec(dllexport) void my_main()
 			LOG(INFO) << "Adding to granny files: " << (char *)entry.path().u8string().c_str();
 		}
 	}
+
+	// Scan for SJSON overlay files (plugins_data/*/<SJSON_DATA_DIR_NAME>/)
+	sjson_overlay::scan_all_plugin_content_directories(g_file_manager.get_project_folder("plugins_data").get_path());
 
 	const auto res = lovely_init((const char *)g_file_manager.get_project_folder("plugins").get_path().u8string().c_str());
 	LOG(INFO) << "lovely_init returned " << (int32_t)res;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1668,6 +1668,14 @@ std::unordered_map<std::string, std::string> additional_granny_files;
 
 std::unordered_map<std::string, std::string> additional_map_files;
 
+struct vo_file_registry
+{
+	std::unordered_map<std::string, std::string> fsb_files;
+	std::unordered_map<std::string, std::string> txt_files;
+};
+
+vo_file_registry additional_vo_files;
+
 // Simple glob match supporting a single '*' wildcard (e.g. "F_*.map_text")
 static bool glob_match(const std::string& pattern, const std::string& str)
 {
@@ -1686,11 +1694,11 @@ static bool glob_match(const std::string& pattern, const std::string& str)
 
 //static std::string g_current_custom_package_stem;
 
-static void hook_fsAppendPathComponent_packages(const char *basePath, const char *pathComponent, char *output /*size: 512*/)
+static void hook_fsAppendPathComponent(const char *basePath, const char *pathComponent, char *output /*size: 512*/)
 {
 	//g_current_custom_package_stem = "";
 
-	big::g_hooking->get_original<hook_fsAppendPathComponent_packages>()(basePath, pathComponent, output);
+	big::g_hooking->get_original<hook_fsAppendPathComponent>()(basePath, pathComponent, output);
 
 	if (strlen(pathComponent) > 0)
 	{
@@ -1723,14 +1731,42 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 			}
 		}
 
-		for (const auto &[filename, full_file_path] : additional_map_files)
 		{
-			if (strcmp(filename.c_str(), pathComponent) == 0)
+			auto it = additional_map_files.find(pathComponent);
+			if (it != additional_map_files.end())
 			{
-				LOG(DEBUG) << pathComponent << " | " << filename << " | " << full_file_path;
+				LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
 
-				strcpy(output, full_file_path.c_str());
-				break;
+				strcpy(output, it->second.c_str());
+			}
+		}
+
+		// VO files: pathComponent includes subdir prefix (e.g. "VO\Zagreus.fsb"), match by filename
+		{
+			const char* vo_filename = strrchr(pathComponent, '\\');
+			if (!vo_filename)
+			{
+				vo_filename = strrchr(pathComponent, '/');
+			}
+			vo_filename = vo_filename ? vo_filename + 1 : pathComponent;
+
+			if (ends_with(vo_filename, ".fsb"))
+			{
+				auto it = additional_vo_files.fsb_files.find(vo_filename);
+				if (it != additional_vo_files.fsb_files.end())
+				{
+					LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
+					strcpy(output, it->second.c_str());
+				}
+			}
+			else if (ends_with(vo_filename, ".txt"))
+			{
+				auto it = additional_vo_files.txt_files.find(vo_filename);
+				if (it != additional_vo_files.txt_files.end())
+				{
+					LOG(DEBUG) << pathComponent << " | " << it->first << " | " << it->second;
+					strcpy(output, it->second.c_str());
+				}
 			}
 		}
 
@@ -1752,9 +1788,9 @@ static void hook_fsAppendPathComponent_packages(const char *basePath, const char
 	}
 }
 
-static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char *subDirectory, wchar_t *extension, eastl::vector<eastl::string> *out)
+static void hook_fsGetFilesWithExtension(PVOID resourceDir, const char *subDirectory, wchar_t *extension, eastl::vector<eastl::string> *out)
 {
-	big::g_hooking->get_original<hook_fsGetFilesWithExtension_packages>()(resourceDir, subDirectory, extension, out);
+	big::g_hooking->get_original<hook_fsGetFilesWithExtension>()(resourceDir, subDirectory, extension, out);
 
 	// Resolve the ResourceDirectory to its physical path so we can match the correct sjson files (and not include those that belong to a different group)
 	std::string resolved_base_dir;
@@ -1840,6 +1876,35 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 				{
 					out->push_back(filename.c_str());
 					existing.insert(filename);
+				}
+			}
+		}
+	}
+
+	// VO file injection: inject additional .fsb files when engine enumerates voiceover files
+	// The engine scans Audio/Desktop/ with subDirectory="VO" and extension="*.fsb"
+	if (extension)
+	{
+		const char* ext_as_char_vo = reinterpret_cast<const char*>(extension);
+		if (ext_as_char_vo && strstr(ext_as_char_vo, ".fsb"))
+		{
+			std::string subdir_str = subDirectory ? subDirectory : "";
+			std::unordered_set<std::string> existing;
+			for (const auto& f : *out)
+			{
+				existing.insert(f.c_str());
+			}
+
+			for (const auto& [filename, filepath] : additional_vo_files.fsb_files)
+			{
+
+				// Build entry with subdir prefix if present (engine expects "VO\\filename.fsb")
+				std::string entry = subdir_str.empty() ? filename : subdir_str + "\\" + filename;
+
+				if (existing.find(entry) == existing.end())
+				{
+					out->push_back(entry.c_str());
+					existing.insert(entry);
 				}
 			}
 		}
@@ -1965,7 +2030,6 @@ static void hook_fsGetFilesWithExtension_packages(PVOID resourceDir, const char 
 				{
 					out->push_back(entry_to_inject.c_str());
 					existing.insert(entry_to_inject);
-					LOG(DEBUG) << "[SJSON] Injected '" << entry_to_inject << "' into " << full_engine_subdir;
 				}
 			}
 		}
@@ -2760,8 +2824,8 @@ extern "C" __declspec(dllexport) void my_main()
 		{
 			static auto ptr_func = ptr;
 
-			static auto hook_ = hooking::detour_hook_helper::add_queue<hook_fsGetFilesWithExtension_packages>(
-			    "fsGetFilesWithExtension for packages and models",
+			static auto hook_ = hooking::detour_hook_helper::add_queue<hook_fsGetFilesWithExtension>(
+			    "fsGetFilesWithExtension for mod plugin_data files",
 			    ptr_func);
 		}
 	}
@@ -2805,13 +2869,13 @@ extern "C" __declspec(dllexport) void my_main()
 		{
 			static auto fsAppendPathComponent = fsAppendPathComponent_ptr.as_func<void(const char *, const char *, char *)>();
 
-			static auto hook_once = big::hooking::detour_hook_helper::add_queue<hook_fsAppendPathComponent_packages>(
-			    "hook_fsAppendPathComponent for packages and models",
+			static auto hook_once = big::hooking::detour_hook_helper::add_queue<hook_fsAppendPathComponent>(
+			    "hook_fsAppendPathComponent for mod plugin_data files",
 			    fsAppendPathComponent);
 		}
 		else
 		{
-			LOG(ERROR) << "hook_fsAppendPathComponent for packages and models failure";
+			LOG(ERROR) << "hook_fsAppendPathComponent for mod plugin_data files failure";
 		}
 	}
 
@@ -2865,7 +2929,71 @@ extern "C" __declspec(dllexport) void my_main()
 
 			LOG(INFO) << "Adding to map files: " << (char *)entry.path().u8string().c_str();
 		}
+		else if (entry.path().extension() == ".fsb")
+		{
+			additional_vo_files.fsb_files.emplace((char *)entry.path().filename().u8string().c_str(),
+			                                      (char *)entry.path().u8string().c_str());
+
+			LOG(INFO) << "Adding to VO files: " << (char *)entry.path().u8string().c_str();
+		}
 	}
+
+	// Register .txt companions for each discovered .fsb.
+	// The .txt must be co-located with its .fsb (same directory, same stem).
+	// We don't register all .txt files as they may be unrelated to a voiceover.
+	{
+		for (const auto& [filename, abspath] : additional_vo_files.fsb_files)
+		{
+			auto txt_path = std::filesystem::path(abspath);
+			txt_path.replace_extension(".txt");
+			if (std::filesystem::exists(txt_path))
+			{
+				additional_vo_files.txt_files.emplace((char *)txt_path.filename().u8string().c_str(),
+				                                      (char *)txt_path.u8string().c_str());
+			}
+		}
+	}
+
+	// Validate file pairs: warn if either half of a required pair is missing
+	auto validate_file_pairs = [](const std::unordered_map<std::string, std::string>& files_a,
+	                              const char* ext_a,
+	                              const std::unordered_map<std::string, std::string>& files_b,
+	                              const char* ext_b)
+	{
+		std::unordered_set<std::string> stems_a, stems_b;
+		for (const auto& [filename, _] : files_a)
+		{
+			if (ends_with(filename.c_str(), ext_a))
+			{
+				stems_a.insert(std::filesystem::path(filename).stem().string());
+			}
+		}
+		for (const auto& [filename, _] : files_b)
+		{
+			if (ends_with(filename.c_str(), ext_b))
+			{
+				stems_b.insert(std::filesystem::path(filename).stem().string());
+			}
+		}
+		for (const auto& stem : stems_a)
+		{
+			if (!stems_b.count(stem))
+			{
+				LOG(WARNING) << "File '" << stem << ext_a << "' has no matching " << ext_b << " pair";
+			}
+		}
+		for (const auto& stem : stems_b)
+		{
+			if (!stems_a.count(stem))
+			{
+				LOG(WARNING) << "File '" << stem << ext_b << "' has no matching " << ext_a << " pair";
+			}
+		}
+	};
+
+	validate_file_pairs(additional_package_files, ".pkg", additional_package_files, ".pkg_manifest");
+	validate_file_pairs(additional_map_files, ".map_text", additional_map_files, ".thing_bin");
+	validate_file_pairs(additional_vo_files.fsb_files, ".fsb", additional_vo_files.txt_files, ".txt");
 
 	// Scan for SJSON overlay files (plugins_data/*/<SJSON_DATA_DIR_NAME>/)
 	sjson_overlay::scan_all_plugin_content_directories(g_file_manager.get_project_folder("plugins_data").get_path());

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -1,0 +1,172 @@
+#include "sjson_overlay.hpp"
+
+#include <string/string.hpp>
+
+namespace sjson_overlay
+{
+	std::string normalize_path(const std::string& path)
+	{
+		std::string result = path;
+		std::replace(result.begin(), result.end(), '\\', '/');
+		while (!result.empty() && result.back() == '/')
+		{
+			result.pop_back();
+		}
+		return result;
+	}
+
+	bool is_known_engine_directory(const std::string& normalized_subdir)
+	{
+		std::string lower = big::string::to_lower(normalized_subdir);
+
+		// Check for text directories: game/text/{locale}
+		if (lower.find("game/text/") == 0)
+		{
+			std::string locale = lower.substr(10); // len("game/text/") = 10
+			for (const auto& known_locale : g_known_text_locales)
+			{
+				if (locale == known_locale)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		for (const auto& known : g_known_engine_directories)
+		{
+			if (lower == known)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
+	{
+		std::string normalized = normalize_path(logical_relpath);
+
+		// Extract directory and extension
+		std::string subdir;
+		std::string filename;
+		auto last_slash = normalized.rfind('/');
+		if (last_slash != std::string::npos)
+		{
+			subdir   = normalized.substr(0, last_slash);
+			filename = normalized.substr(last_slash + 1);
+		}
+		else
+		{
+			filename = normalized;
+		}
+
+		std::string extension;
+		auto dot_pos = filename.rfind('.');
+		if (dot_pos != std::string::npos)
+		{
+			extension = filename.substr(dot_pos);
+		}
+
+		if (big::string::to_lower(extension) != ".sjson")
+		{
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
+			return false;
+		}
+
+		if (!is_known_engine_directory(subdir))
+		{
+			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
+			             << "' is in a directory not known to be scanned by the engine. "
+			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
+			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
+		}
+
+		std::unique_lock lock(g_overlay_mutex);
+
+		if (g_path_index.count(normalized))
+		{
+			return false;
+		}
+
+		g_path_index[normalized] = absolute_path;
+
+		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
+		if (g_enumerated_directories.count(enum_key))
+		{
+			LOG(WARNING) << "[SJSON] File '" << normalized
+			             << "' registered after engine enumerated '" << subdir
+			             << "'. Will not be loaded until next launch.";
+		}
+
+		LOG(INFO) << "Adding to SJSON files: " << absolute_path;
+		return true;
+	}
+
+	void scan_content_directory(const std::filesystem::path& content_base_path)
+	{
+		if (!std::filesystem::exists(content_base_path))
+		{
+			return;
+		}
+
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(
+		         content_base_path,
+		         std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
+		{
+			if (!entry.is_regular_file() || entry.path().extension() != ".sjson")
+			{
+				continue;
+			}
+
+			auto rel_path   = std::filesystem::relative(entry.path(), content_base_path);
+			std::string rel = (char*)rel_path.u8string().c_str();
+			std::string abs = (char*)entry.path().u8string().c_str();
+
+			std::string logical_rel = "Game/" + normalize_path(rel);
+			register_content_file(logical_rel, abs);
+		}
+	}
+
+	void scan_all_plugin_content_directories(const std::filesystem::path& plugins_data_path)
+	{
+		if (!std::filesystem::exists(plugins_data_path))
+		{
+			return;
+		}
+
+		for (const auto& mod_dir : std::filesystem::directory_iterator(
+		         plugins_data_path,
+		         std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
+		{
+			if (!mod_dir.is_directory())
+			{
+				continue;
+			}
+
+			auto sjson_dir = mod_dir.path() / SJSON_DATA_DIR_NAME;
+			if (std::filesystem::exists(sjson_dir) && std::filesystem::is_directory(sjson_dir))
+			{
+				scan_content_directory(sjson_dir);
+			}
+		}
+	}
+
+	void mark_directory_enumerated(const std::string& normalized_subdir, const std::string& extension)
+	{
+		std::unique_lock lock(g_overlay_mutex);
+		g_enumerated_directories.insert(big::string::to_lower(normalized_subdir) + "|" + big::string::to_lower(extension));
+	}
+
+	std::string lookup_overlay_path(const std::string& normalized_relpath)
+	{
+		std::shared_lock lock(g_overlay_mutex);
+		auto it = g_path_index.find(normalized_relpath);
+		if (it != g_path_index.end())
+		{
+			return it->second;
+		}
+		return "";
+	}
+} // namespace sjson_overlay

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -46,21 +46,20 @@ namespace sjson_overlay
 
 	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
 	{
-		// Canonical lowercase key for case-insensitive matching on Windows
-		std::string key = big::string::to_lower(normalize_path(logical_relpath));
+		std::string normalized = normalize_path(logical_relpath);
 
 		// Extract directory and extension
 		std::string subdir;
 		std::string filename;
-		auto last_slash = key.rfind('/');
+		auto last_slash = normalized.rfind('/');
 		if (last_slash != std::string::npos)
 		{
-			subdir   = key.substr(0, last_slash);
-			filename = key.substr(last_slash + 1);
+			subdir   = normalized.substr(0, last_slash);
+			filename = normalized.substr(last_slash + 1);
 		}
 		else
 		{
-			filename = key;
+			filename = normalized;
 		}
 
 		std::string extension;
@@ -70,15 +69,15 @@ namespace sjson_overlay
 			extension = filename.substr(dot_pos);
 		}
 
-		if (extension != ".sjson")
+		if (big::string::to_lower(extension) != ".sjson")
 		{
-			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << key;
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
 			return false;
 		}
 
 		if (!is_known_engine_directory(subdir))
 		{
-			LOG(WARNING) << "[SJSON] SJSON file '" << key
+			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
 			             << "' is in a directory not known to be scanned by the engine. "
 			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
 			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
@@ -86,19 +85,21 @@ namespace sjson_overlay
 
 		std::unique_lock lock(g_overlay_mutex);
 
-		if (g_path_index.count(key))
+		if (g_path_index.count(normalized))
 		{
-			LOG(WARNING) << "[SJSON] Duplicate: '" << key << "' already registered from '"
-			             << g_path_index[key] << "', ignoring '" << absolute_path << "'";
+			if (g_path_index[normalized] != absolute_path)
+			{
+				LOG(WARNING) << "[SJSON] File '" << normalized << "' already registered from '" << g_path_index[normalized] << "', ignoring '" << absolute_path << "'";
+			}
 			return false;
 		}
 
-		g_path_index[key] = absolute_path;
+		g_path_index[normalized] = absolute_path;
 
-		std::string enum_key = subdir + "|" + extension;
+		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
 		if (g_enumerated_directories.count(enum_key))
 		{
-			LOG(WARNING) << "[SJSON] File '" << key
+			LOG(WARNING) << "[SJSON] File '" << normalized
 			             << "' registered after engine enumerated '" << subdir
 			             << "'. Will not be loaded until next launch.";
 		}
@@ -165,7 +166,7 @@ namespace sjson_overlay
 	std::string lookup_overlay_path(const std::string& normalized_relpath)
 	{
 		std::shared_lock lock(g_overlay_mutex);
-		auto it = g_path_index.find(big::string::to_lower(normalized_relpath));
+		auto it = g_path_index.find(normalized_relpath);
 		if (it != g_path_index.end())
 		{
 			return it->second;

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -46,20 +46,21 @@ namespace sjson_overlay
 
 	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path)
 	{
-		std::string normalized = normalize_path(logical_relpath);
+		// Canonical lowercase key for case-insensitive matching on Windows
+		std::string key = big::string::to_lower(normalize_path(logical_relpath));
 
 		// Extract directory and extension
 		std::string subdir;
 		std::string filename;
-		auto last_slash = normalized.rfind('/');
+		auto last_slash = key.rfind('/');
 		if (last_slash != std::string::npos)
 		{
-			subdir   = normalized.substr(0, last_slash);
-			filename = normalized.substr(last_slash + 1);
+			subdir   = key.substr(0, last_slash);
+			filename = key.substr(last_slash + 1);
 		}
 		else
 		{
-			filename = normalized;
+			filename = key;
 		}
 
 		std::string extension;
@@ -69,15 +70,15 @@ namespace sjson_overlay
 			extension = filename.substr(dot_pos);
 		}
 
-		if (big::string::to_lower(extension) != ".sjson")
+		if (extension != ".sjson")
 		{
-			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << normalized;
+			LOG(WARNING) << "[SJSON] Only .sjson files are supported. Ignoring: " << key;
 			return false;
 		}
 
 		if (!is_known_engine_directory(subdir))
 		{
-			LOG(WARNING) << "[SJSON] SJSON file '" << normalized
+			LOG(WARNING) << "[SJSON] SJSON file '" << key
 			             << "' is in a directory not known to be scanned by the engine. "
 			             << "Known directories: Game/, Game/Animations/, Game/GUI/, Game/Obstacles/, "
 			             << "Game/Units/, Game/Weapons/, Game/Projectiles/, Game/Text/{lang}/";
@@ -85,17 +86,17 @@ namespace sjson_overlay
 
 		std::unique_lock lock(g_overlay_mutex);
 
-		if (g_path_index.count(normalized))
+		if (g_path_index.count(key))
 		{
 			return false;
 		}
 
-		g_path_index[normalized] = absolute_path;
+		g_path_index[key] = absolute_path;
 
-		std::string enum_key = big::string::to_lower(subdir) + "|" + big::string::to_lower(extension);
+		std::string enum_key = subdir + "|" + extension;
 		if (g_enumerated_directories.count(enum_key))
 		{
-			LOG(WARNING) << "[SJSON] File '" << normalized
+			LOG(WARNING) << "[SJSON] File '" << key
 			             << "' registered after engine enumerated '" << subdir
 			             << "'. Will not be loaded until next launch.";
 		}
@@ -162,7 +163,7 @@ namespace sjson_overlay
 	std::string lookup_overlay_path(const std::string& normalized_relpath)
 	{
 		std::shared_lock lock(g_overlay_mutex);
-		auto it = g_path_index.find(normalized_relpath);
+		auto it = g_path_index.find(big::string::to_lower(normalized_relpath));
 		if (it != g_path_index.end())
 		{
 			return it->second;

--- a/src/sjson_overlay.cpp
+++ b/src/sjson_overlay.cpp
@@ -88,6 +88,8 @@ namespace sjson_overlay
 
 		if (g_path_index.count(key))
 		{
+			LOG(WARNING) << "[SJSON] Duplicate: '" << key << "' already registered from '"
+			             << g_path_index[key] << "', ignoring '" << absolute_path << "'";
 			return false;
 		}
 

--- a/src/sjson_overlay.hpp
+++ b/src/sjson_overlay.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <filesystem>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace sjson_overlay
+{
+	// The canonical directory name for SJSON data overlays within each mod's plugins_data folder.
+	// Mods place .sjson files in plugins_data/<mod-guid>/<SJSON_DATA_DIR_NAME>/Animations/, Text/{lang}/, etc.
+	inline constexpr const char* SJSON_DATA_DIR_NAME = "Hell2Modding-SJSON";
+
+	// Known engine-scanned directories under Content/Game/ (lowercase, forward slashes).
+	// .sjson files outside these directories get a validation warning.
+	inline const std::vector<std::string> g_known_engine_directories = {
+	    "game",
+	    "game/animations",
+	    "game/gui",
+	    "game/obstacles",
+	    "game/projectiles",
+	    "game/units",
+	    "game/weapons",
+	};
+
+	// Known locale subdirectories under Game/Text/ (lowercase).
+	inline const std::vector<std::string> g_known_text_locales = {
+	    "de", "el", "en", "es", "fr", "it", "ja", "ko",
+	    "pl", "pt-br", "ru", "tr", "uk", "zh-cn", "zh-tw",
+	};
+
+	// Path index: logical_relpath (normalized, forward slashes) -> absolute_path
+	inline std::unordered_map<std::string, std::string> g_path_index;
+
+	// Tracks which (subdir, extension) pairs the engine has already enumerated
+	inline std::unordered_set<std::string> g_enumerated_directories;
+
+	inline std::shared_mutex g_overlay_mutex;
+
+	std::string normalize_path(const std::string& path);
+	bool is_known_engine_directory(const std::string& normalized_subdir);
+	bool register_content_file(const std::string& logical_relpath, const std::string& absolute_path);
+	void scan_content_directory(const std::filesystem::path& content_base_path);
+	void scan_all_plugin_content_directories(const std::filesystem::path& plugins_data_path);
+	void mark_directory_enumerated(const std::string& normalized_subdir, const std::string& extension);
+	std::string lookup_overlay_path(const std::string& normalized_relpath);
+} // namespace sjson_overlay


### PR DESCRIPTION
This allows mod authors to place various file types into `plugins_data`: bink video files: `.bik`, `.bik_atlas`, map files: `.map_text`, `.thing_bin`, VO: `.fsb`, `.txt`

There is a special case for `.sjson` files, which the game loads in groups, so H2M enforces this structure as well. `.sjson` files must be placed in `plugins_data/<mod-guid>/Hell2Modding-SJSON/*`, where the subdirectories in `Hell2Modding-SJSON` MUST match `Game/` directories in Hades II - such as `Animations`, `Text/en/` etc. 
A mod author can get the absolute path to the `Hell2Modding-SJSON` directory by using the new `_PLUGIN.sjson_data_path`.

Also supports runtime creation+registration in case files are only created in the `plugins_data` when the game runs, e.g. during a mod installation operation (required for Zagreus' Journey)