### PR TITLE
Add draw Lua bindings + raise static GPU buffer pool sizes

### DIFF
--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -8,6 +8,7 @@
 #include <lua_extensions/lua_manager_extension.hpp>
 #include <lua_extensions/lua_module_ext.hpp>
 #include <memory/gm_address.hpp>
+#include <mutex>
 #include <string/string.hpp>
 
 namespace sgg

--- a/src/lua_extensions/bindings/hades/draw.cpp
+++ b/src/lua_extensions/bindings/hades/draw.cpp
@@ -1,36 +1,3 @@
-/// @file draw.cpp
-/// @brief Draw-call control for 3D model entries.
-///
-/// Provides Lua APIs for controlling 3D model rendering at runtime:
-///
-///   rom.data.set_draw_visible(entry, visible)
-///     Show/hide an entire entry across all draw passes.
-///
-///   rom.data.set_mesh_visible(entry, mesh_name, visible)
-///     Show/hide a single mesh inside an entry.
-///
-///   rom.data.swap_to_variant(stock, variant)
-///   rom.data.restore_stock(stock)
-///     Redirect a stock entry's draw calls to a variant entry.
-///     Enables outfit switching without reload.  swap_to_variant
-///     pre-populates the variant's texture handles before installing
-///     the remap so the first swapped frame renders correctly.
-///
-///   rom.data.populate_entry_textures(entry)
-///     Pre-populate an entry's texture handles without remapping.
-///     Useful for variant entries the scene isn't actively rendering.
-///
-///   rom.data.dump_pool_stats()
-///     Diagnostic: log vertex/index pool cursor + capacity per
-///     shader effect.
-///
-/// Hooks DoDraw3D / DoDrawShadow3D / DoDraw3DThumbnail (share the
-/// `static void(const vector<RenderMesh*>&, uint, int, HashGuid)`
-/// signature) with standard detours.  DoDrawShadowCast3D has a
-/// different signature (no HashGuid) so its remap would need a
-/// code-cave approach not included here — it participates in the
-/// hidden-set but not in hash remap.
-
 #include "draw.hpp"
 
 #include "hades_ida.hpp"
@@ -49,6 +16,180 @@
 
 namespace lua::hades::draw
 {
+	// ─── Game structs ─────────────────────────────────────────────────
+	//
+	// Only the fields we touch are named; unknown regions are
+	// `char pad[]` so `sizeof` and offsetof match the engine's layout.
+	// Access is always through safe_read_* helpers (see below) because
+	// these pointers can be half-constructed during load and a wrong
+	// guess here should log a fault, not crash.
+
+	struct ModelDataNode;
+
+	struct ModelDataHashTable
+	{
+		char pad_00[0x08];
+		ModelDataNode** buckets; // +0x08
+		uint64_t bucket_count;   // +0x10
+	};
+	static_assert(offsetof(ModelDataHashTable, buckets) == 0x08);
+	static_assert(offsetof(ModelDataHashTable, bucket_count) == 0x10);
+
+	struct GrannyMeshData
+	{
+		char pad_00[0x40];
+		uint32_t texture_name_hash; // +0x40 — feeds GetTexture
+		uint32_t texture_handle;    // +0x44 — resolved bindless handle
+		uint32_t mesh_name_hash;    // +0x48 — sgg::HashGuid of the mesh's name
+		uint8_t mesh_type;          // +0x4C — 0 main, 1 outline, 2 shadow/hidden
+		char pad_4D[3];
+	};
+	static_assert(offsetof(GrannyMeshData, texture_name_hash) == 0x40);
+	static_assert(offsetof(GrannyMeshData, texture_handle) == 0x44);
+	static_assert(offsetof(GrannyMeshData, mesh_name_hash) == 0x48);
+	static_assert(offsetof(GrannyMeshData, mesh_type) == 0x4C);
+	static_assert(sizeof(GrannyMeshData) == 0x50);
+
+	struct ModelDataNode
+	{
+		uint32_t id;                       // +0x00 — HashGuid.mId of the entry
+		char pad_04[0x0C];
+		GrannyMeshData* mesh_vec_begin;    // +0x10 — eastl::vector<GrannyMeshData>::mpBegin
+		GrannyMeshData* mesh_vec_end;      // +0x18 — ::mpEnd
+		char pad_20[0xA0];
+		ModelDataNode* next;               // +0xC0 — EASTL hashtable chain
+	};
+	static_assert(offsetof(ModelDataNode, id) == 0x00);
+	static_assert(offsetof(ModelDataNode, mesh_vec_begin) == 0x10);
+	static_assert(offsetof(ModelDataNode, mesh_vec_end) == 0x18);
+	static_assert(offsetof(ModelDataNode, next) == 0xC0);
+
+	// ForgeRenderer-side types used only by draw_dump_pool_stats.
+	struct ForgeBuffer
+	{
+		char pad_00[0x38];
+		uint64_t size_raw; // +0x38 — low dword = byte size, high dword = flags
+	};
+	static_assert(offsetof(ForgeBuffer, size_raw) == 0x38);
+
+	struct ForgeGeometryBuffers
+	{
+		char pad_00[0x20];
+		ForgeBuffer* buffer;     // +0x20
+		char pad_28[0x18];
+		uint32_t vertex_cursor;  // +0x40 — next free vertex slot
+		char pad_44[0x04];
+	};
+	static_assert(offsetof(ForgeGeometryBuffers, buffer) == 0x20);
+	static_assert(offsetof(ForgeGeometryBuffers, vertex_cursor) == 0x40);
+	static_assert(sizeof(ForgeGeometryBuffers) == 72);
+
+	// EASTL vector header (first 16 bytes are mpBegin / mpEnd; we don't
+	// touch mpCapacityEnd).  Templatized so we can reuse it for both
+	// eastl::vector<ForgeGeometryBuffers> and any future consumer.
+	template <class T>
+	struct EastlVector
+	{
+		T* mpBegin;   // +0x00
+		T* mpEnd;     // +0x08
+	};
+
+	// Mixing constants pulled from the game's integer-key hashtable
+	// (multiply-xor-shift finalizer).  We have to match them exactly to
+	// reproduce the same bucket index the game assigns to a given entry
+	// hash — otherwise our bucket walk finds the wrong chain.
+	constexpr uint32_t kEastlHashMix1 = 0x7feb352d;
+	constexpr uint32_t kEastlHashMix2 = 0x846ca68b;
+
+	// Sanity bounds — a live mModelData never exceeds these.
+	constexpr uint64_t kMaxBucketCount  = 0x100000;
+	constexpr int      kBucketWalkGuard = 32;
+	constexpr size_t   kMaxMeshesPerEntry = 128;
+
+	// Sentinel mesh_type used to hide a single mesh inside an entry —
+	// DoDraw3D's own mesh-type switch skips meshes with this value.
+	constexpr uint8_t kMeshTypeHidden = 2;
+
+	// ─── SEH-protected pointer reads ──────────────────────────────────
+	// The mModelData walk touches pointers that can be null or
+	// half-initialized during load/unload.
+
+	static int __stdcall safe_read_u64(const void* addr, uint64_t* out_val)
+	{
+		__try { *out_val = *(const uint64_t*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	static int __stdcall safe_read_u32(const void* addr, uint32_t* out_val)
+	{
+		__try { *out_val = *(const uint32_t*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	static int __stdcall safe_read_ptr(const void* addr, void** out_val)
+	{
+		__try { *out_val = *(void* const*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	// ─── Hashtable walker (shared between bindings) ───────────────────
+	//
+	// Returns the ModelDataNode for `entry_hash`, or nullptr if not
+	// found / any read faults.  Every binding that reads per-mesh state
+	// uses this — before extraction, each one inlined the same EASTL
+	// mix + bucket walk.
+
+	static ModelDataNode* find_model_data_node(uint32_t entry_hash)
+	{
+		auto mdata_addr = big::hades2_symbol_to_address["sgg::Granny3D::mModelData"];
+		if (!mdata_addr) return nullptr;
+
+		auto* table = mdata_addr.as<const ModelDataHashTable*>();
+
+		ModelDataNode** buckets = nullptr;
+		uint64_t bucket_count = 0;
+		if (!safe_read_ptr(&table->buckets, (void**)&buckets)) return nullptr;
+		if (!safe_read_u64(&table->bucket_count, &bucket_count)) return nullptr;
+		if (!buckets || !bucket_count || bucket_count > kMaxBucketCount) return nullptr;
+
+		uint32_t h = entry_hash;
+		h = ((h >> 16) ^ h) * kEastlHashMix1;
+		h = ((h >> 15) ^ h) * kEastlHashMix2;
+		h = (h >> 16) ^ h;
+
+		ModelDataNode* node = nullptr;
+		if (!safe_read_ptr(&buckets[h % bucket_count], (void**)&node)) return nullptr;
+
+		for (int guard = 0; node && guard < kBucketWalkGuard; ++guard)
+		{
+			uint32_t id = 0;
+			if (!safe_read_u32(&node->id, &id)) return nullptr;
+			if (id == entry_hash) return node;
+			ModelDataNode* nxt = nullptr;
+			if (!safe_read_ptr(&node->next, (void**)&nxt)) return nullptr;
+			node = nxt;
+		}
+		return nullptr;
+	}
+
+	// Resolve the node's GrannyMeshData range.  Returns false on any
+	// fault or if the range is empty / implausibly large.
+	static bool get_entry_meshes(const ModelDataNode* node,
+	                             GrannyMeshData** out_begin,
+	                             size_t* out_count)
+	{
+		GrannyMeshData* vb = nullptr;
+		GrannyMeshData* ve = nullptr;
+		if (!safe_read_ptr(&node->mesh_vec_begin, (void**)&vb)) return false;
+		if (!safe_read_ptr(&node->mesh_vec_end, (void**)&ve)) return false;
+		if (!vb || !ve || ve < vb) return false;
+		size_t count = (size_t)((uintptr_t)ve - (uintptr_t)vb) / sizeof(GrannyMeshData);
+		if (count == 0 || count > kMaxMeshesPerEntry) return false;
+		*out_begin = vb;
+		*out_count = count;
+		return true;
+	}
+
 	// ─── State ─────────────────────────────────────────────────────────
 
 	static std::shared_mutex g_mutex;
@@ -64,20 +205,29 @@ namespace lua::hades::draw
 		g_any_active = (g_hidden_entries.empty() && g_remap.empty()) ? 0 : 1;
 	}
 
+	// Return values for check_draw_entry.  Numeric layout is load-bearing:
+	// the code cave compares the returned eax against the raw integers, so
+	// the enum stays `: int` and the values must not be reordered.
+	enum class DrawEntryDecision : int
+	{
+		PassThrough = 0,
+		Hidden      = 1,
+		Remapped    = 2,
+	};
+
 	// Called from the code cave via function pointer.
-	// Returns: 0 = pass through, 1 = hidden (skip), 2 = remapped (*out_hash set)
-	static int check_draw_entry(uint32_t hash, uint32_t* out_hash)
+	static DrawEntryDecision check_draw_entry(uint32_t hash, uint32_t* out_hash)
 	{
 		std::shared_lock l(g_mutex);
 		auto it = g_remap.find(hash);
 		if (it != g_remap.end())
 		{
 			*out_hash = it->second;
-			return 2;
+			return DrawEntryDecision::Remapped;
 		}
 		if (g_hidden_entries.count(hash))
-			return 1;
-		return 0;
+			return DrawEntryDecision::Hidden;
+		return DrawEntryDecision::PassThrough;
 	}
 
 	// ─── Detour hooks (DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail) ──
@@ -273,18 +423,16 @@ namespace lua::hades::draw
 
 	// Lua API: Function
 	// Table: data
-	// Name: set_draw_visible
+	// Name: draw_set_visible
 	// Param: entry_name: string: Model entry name (e.g. "HecateBattle_Mesh").
 	// Param: visible: boolean: true to show, false to hide.
-	// Toggles visibility of a model entry by suppressing its draw calls
-	// (DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail, DoDrawShadowCast3D).
-	// Takes effect immediately — no rebuild, no restart, no data mutation.
+	// Toggles visibility of a model entry.  Takes effect immediately.
 	//
 	// **Example Usage:**
 	// ```lua
-	// rom.data.set_draw_visible("HecateBattle_Mesh", false)
+	// rom.data.draw_set_visible("HecateBattle_Mesh", false)
 	// ```
-	static void set_draw_visible(const std::string& entry_name, bool visible)
+	static void draw_set_visible(const std::string& entry_name, bool visible)
 	{
 		static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
 		    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
@@ -294,8 +442,15 @@ namespace lua::hades::draw
 
 		if (guid.mId == 0)
 		{
-			LOG(WARNING) << "draw: hash=0 for '" << entry_name
-			             << "' — hash system not ready, skipping";
+			// HashGuid::Lookup returns 0 either because the string interner
+			// isn't populated yet (pre-first-scene) or because the caller
+			// passed an entry name the game has never registered (typo,
+			// mod not loaded).  Either way there's no entry to toggle, so
+			// this call is a no-op; try again after the first scene loads
+			// or double-check the name.
+			LOG(WARNING) << "draw_set_visible: '" << entry_name
+			             << "' — no HashGuid found (engine hash table not yet "
+			                "populated, or entry name isn't registered); skipping";
 			return;
 		}
 
@@ -318,122 +473,89 @@ namespace lua::hades::draw
 		          << ", set " << old_size << " -> " << new_size << ")";
 	}
 
-	// ─── SEH-protected pointer reads ──────────────────────────────────
-	// populate_entry_textures / set_mesh_visible / swap_to_variant walk
-	// the game's mModelData hash-bucket structure via raw pointers.  Any
-	// step can fault if the layout shifts after a game update; these
-	// helpers let callers detect and log a fault instead of crashing.
-	// Plain C (no C++ objects) so __try / __except are legal.
-	static int __stdcall safe_read_u64(const void* addr, uint64_t* out_val)
-	{
-		__try { *out_val = *(const uint64_t*)addr; return 1; }
-		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
-	}
-
-	static int __stdcall safe_read_u32(const void* addr, uint32_t* out_val)
-	{
-		__try { *out_val = *(const uint32_t*)addr; return 1; }
-		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
-	}
-
-	static int __stdcall safe_read_ptr(const void* addr, void** out_val)
-	{
-		__try { *out_val = *(void* const*)addr; return 1; }
-		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
-	}
-
 	// ─── Registration ─────────────────────────────────────────────────
 
 	void bind(sol::state_view& state, sol::table& lua_ext)
 	{
 		auto ns = lua_ext["data"].get_or_create<sol::table>();
-		ns.set_function("set_draw_visible", set_draw_visible);
+		ns.set_function("draw_set_visible", draw_set_visible);
 
 		// Lua API: Function
 		// Table: data
-		// Name: dump_pool_stats
+		// Name: draw_dump_pool_stats
 		// Returns: integer — number of per-shader vertex buffers dumped.
-		// Walks sgg::gStaticDrawBuffers and logs each shader-effect's
-		// vertex pool: total capacity (Buffer.mSize &0xFFFFFFFF at +0x38),
-		// cursor (+0x40 of ForgeGeometryBuffers — next-free vertex slot),
-		// stride (from gShaderEffects[i].+0x95c).  Also logs the single
-		// global gStaticIndexBuffers cursor + size.
-		ns.set_function("dump_pool_stats", []() -> int {
-			auto draw_buf_vec = big::hades2_symbol_to_address["sgg::gStaticDrawBuffers"];
-			auto idx_buf_ptr  = big::hades2_symbol_to_address["sgg::gStaticIndexBuffers"];
-			auto idx_off_ptr  = big::hades2_symbol_to_address["sgg::gStaticIndexBufferOffset"];
+		// Logs vertex-pool and index-pool capacity and cursor usage.
+		// Diagnostic only — useful when tuning the pool size config
+		// against a mod load-out.
+		ns.set_function("draw_dump_pool_stats", []() -> int {
+			constexpr size_t kCharacterVertexStride = 40;
+			constexpr size_t kIndexByteStride       = 2;
+			constexpr size_t kMaxGeoBuffersLogged   = 128;
+			constexpr double kBytesPerMiB           = 1024.0 * 1024.0;
+
+			auto draw_buf_vec   = big::hades2_symbol_to_address["sgg::gStaticDrawBuffers"];
+			auto idx_buf_ptr    = big::hades2_symbol_to_address["sgg::gStaticIndexBuffers"];
+			auto idx_off_ptr    = big::hades2_symbol_to_address["sgg::gStaticIndexBufferOffset"];
 			auto shader_effects = big::hades2_symbol_to_address["sgg::gShaderEffects"];
 			if (!draw_buf_vec || !idx_buf_ptr || !idx_off_ptr || !shader_effects)
 			{
-				LOG(ERROR) << "dump_pool_stats: symbols missing";
+				LOG(ERROR) << "draw_dump_pool_stats: symbols missing";
 				return 0;
 			}
-			auto vec = draw_buf_vec.as<uint8_t *>();
-			auto vec_begin = *(uint8_t **)(vec + 0x00);
-			auto vec_end   = *(uint8_t **)(vec + 0x08);
-			size_t count = (vec_end - vec_begin) / 72;
+
+			const auto* vec = draw_buf_vec.as<const EastlVector<ForgeGeometryBuffers>*>();
+			size_t count = (size_t)(vec->mpEnd - vec->mpBegin);
 			LOG(INFO) << "=== Static vertex pool stats (" << count << " geo buffers) ===";
+
 			// The shader→geo mapping isn't 1:1 (addShaderEffect calls
-			// addStaticVertexBuffers twice with different sizes per effect),
-			// so deriving the real per-shader byte stride from the geo
-			// index alone is wrong.  Instead, report raw cursor + capacity,
-			// plus a rough estimate at the common 40 B character-vertex
-			// stride.  Only the raw cursor / capacity should be trusted.
+			// addStaticVertexBuffers twice with different sizes per
+			// effect), so we can't derive the real per-shader byte
+			// stride.  Log raw cursor + capacity and a rough estimate
+			// at the 40-byte character-vertex stride.
 			int logged = 0;
-			for (size_t i = 0; i < count && i < 128; ++i)
+			for (size_t i = 0; i < count && i < kMaxGeoBuffersLogged; ++i)
 			{
-				uint8_t *geo = vec_begin + i * 72;
-				uint8_t *buf = *(uint8_t **)(geo + 0x20);
-				if (!buf) continue;
-				uint32_t cursor = *(uint32_t *)(geo + 0x40);
-				uint64_t msize_raw = *(uint64_t *)(buf + 0x38);
-				uint32_t msize = (uint32_t)msize_raw;
-				double cap_mb = msize / (1024.0 * 1024.0);
-				double est_mb = (uint64_t)cursor * 40 / (1024.0 * 1024.0);
+				const ForgeGeometryBuffers& geo = vec->mpBegin[i];
+				if (!geo.buffer) continue;
+				uint32_t cursor = geo.vertex_cursor;
+				uint32_t msize  = (uint32_t)geo.buffer->size_raw; // low dword = bytes
+				double cap_mb = msize / kBytesPerMiB;
+				double est_mb = (uint64_t)cursor * kCharacterVertexStride / kBytesPerMiB;
 				LOG(INFO) << "  geo[" << i << "]: capacity=" << cap_mb
 				          << " MB  cursor=" << cursor << " verts (~"
-				          << est_mb << " MB @ 40B/vert)";
+				          << est_mb << " MB @ " << kCharacterVertexStride << "B/vert)";
 				logged++;
 			}
-			// Index buffer uses fixed 2-byte stride — bounds check is
-			// exact, so this % is reliable (unlike the vertex-pool one).
-			uint8_t *ibuf = *idx_buf_ptr.as<uint8_t **>();
+
+			auto* ibuf = *idx_buf_ptr.as<ForgeBuffer* const*>();
 			uint32_t ioff = *idx_off_ptr.as<uint32_t *>();
 			if (ibuf)
 			{
-				uint64_t imsize_raw = *(uint64_t *)(ibuf + 0x38);
-				uint32_t imsize = (uint32_t)imsize_raw;
-				uint64_t iused = (uint64_t)ioff * 2;
+				uint32_t imsize = (uint32_t)ibuf->size_raw;
+				uint64_t iused  = (uint64_t)ioff * kIndexByteStride;
 				double ipct = imsize ? (100.0 * iused / imsize) : 0.0;
-				LOG(INFO) << "  index buf: " << (iused / (1024.0 * 1024.0)) << " MB / "
-				          << (imsize / (1024.0 * 1024.0)) << " MB (" << ipct << "%)";
+				LOG(INFO) << "  index buf: " << (iused / kBytesPerMiB) << " MB / "
+				          << (imsize / kBytesPerMiB) << " MB (" << ipct << "%)";
 			}
 			return logged;
 		});
 
 		// Lua API: Function
 		// Table: data
-		// Name: populate_entry_textures
+		// Name: draw_populate_entry_textures
 		// Param: entry_name: string
 		// Returns: integer — number of textures populated.
-		//
-		// Walks the entry's GrannyMeshData vector and, for each type=0 mesh whose
-		// GMD+0x40 (texture name hash) is non-zero, calls the game's own
-		// sgg::GameAssetManager::GetTexture(hash, &out_handle) and writes the
-		// result into GMD+0x44.  This mimics what ModelAnimation::PrepDraw does
-		// for stock meshes — variants live alongside stock in mModelData but are
-		// never walked by PrepDraw, so their GMD+0x44 stays 0 (→ white rendering
-		// under hash remap).  Calling this once after loading a variant populates
-		// its texture handles so DoDraw3D's fallback path can resolve them.
-		ns.set_function("populate_entry_textures", [](const std::string& entry) -> int {
+		// Resolves the entry's mesh textures up-front.  Useful for
+		// entries that aren't in the active scene (loaded-but-not-drawn
+		// variants) so their first drawn frame doesn't render white.
+		ns.set_function("draw_populate_entry_textures", [](const std::string& entry) -> int {
 			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
 			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
 			static auto GetTexture = big::hades2_symbol_to_address["sgg::GameAssetManager::GetTexture"]
 			    .as_func<void(void*, uint32_t*, uint32_t)>();
-			auto mdata_addr = big::hades2_symbol_to_address["sgg::Granny3D::mModelData"];
-			if (!Lookup || !GetTexture || !mdata_addr)
+			if (!Lookup || !GetTexture)
 			{
-				LOG(ERROR) << "populate_entry_textures: required symbols missing";
+				LOG(ERROR) << "draw_populate_entry_textures: required symbols missing";
 				return 0;
 			}
 
@@ -441,123 +563,71 @@ namespace lua::hades::draw
 			Lookup(&guid, entry.c_str(), entry.size());
 			if (!guid.mId)
 			{
-				LOG(WARNING) << "populate_entry_textures: hash=0 for '" << entry << "'";
+				LOG(WARNING) << "draw_populate_entry_textures: hash=0 for '" << entry << "'";
 				return 0;
 			}
 
-			uint8_t* mdata = mdata_addr.as<uint8_t*>();
-			void* buckets_ptr = nullptr;
-			uint64_t bucket_count = 0;
-			if (!safe_read_ptr(mdata + 0x08, &buckets_ptr)) return 0;
-			if (!safe_read_u64(mdata + 0x10, &bucket_count)) return 0;
-			if (!buckets_ptr || !bucket_count || bucket_count > 0x100000) return 0;
-
-			uint32_t h = guid.mId;
-			h = ((h >> 16) ^ h) * 0x7feb352d;
-			h = ((h >> 15) ^ h) * 0x846ca68b;
-			h = (h >> 16) ^ h;
-			uint8_t* node = (uint8_t*)((void**)buckets_ptr)[h % bucket_count];
-			int walk_guard = 0;
-			while (node && walk_guard++ < 32)
+			ModelDataNode* node = find_model_data_node(guid.mId);
+			if (!node)
 			{
-				uint32_t id = 0;
-				if (!safe_read_u32(node, &id)) return 0;
-				if (id == guid.mId) break;
-				void* nxt = nullptr;
-				if (!safe_read_ptr(node + 0xC0, &nxt)) return 0;
-				node = (uint8_t*)nxt;
-			}
-			if (!node || walk_guard >= 32)
-			{
-				LOG(WARNING) << "populate_entry_textures: entry '" << entry << "' not found";
+				LOG(WARNING) << "draw_populate_entry_textures: entry '" << entry << "' not found";
 				return 0;
 			}
 
-			void* vb_p = nullptr; void* ve_p = nullptr;
-			if (!safe_read_ptr(node + 0x10, &vb_p)) return 0;
-			if (!safe_read_ptr(node + 0x18, &ve_p)) return 0;
-			uint8_t* vec_begin = (uint8_t*)vb_p;
-			uint8_t* vec_end   = (uint8_t*)ve_p;
-			size_t mesh_count = (vec_end >= vec_begin) ? (size_t)(vec_end - vec_begin) / 0x50 : 0;
-			if (mesh_count == 0 || mesh_count > 128) return 0;
+			GrannyMeshData* meshes = nullptr;
+			size_t mesh_count = 0;
+			if (!get_entry_meshes(node, &meshes, &mesh_count)) return 0;
 
 			int populated = 0;
 			for (size_t i = 0; i < mesh_count; i++)
 			{
-				uint8_t* gmd = vec_begin + i * 0x50;
+				GrannyMeshData& gmd = meshes[i];
 
-				uint32_t mesh_type=0, name_hash=0, old_handle=0;
-				safe_read_u32(gmd + 0x4C, &mesh_type);
-				safe_read_u32(gmd + 0x40, &name_hash);
-				safe_read_u32(gmd + 0x44, &old_handle);
+				// PrepDraw only fills the texture handle for main meshes;
+				// outlines and shadows resolve through other paths.
+				if (gmd.mesh_type != 0) continue;
+				if (gmd.texture_name_hash == 0) continue;
 
-				// Game's PrepDraw path only fills GMD+0x44 for type=0 meshes.
-				// Mirror that guard; outlines (type=1) and shadows (type=2)
-				// use different resolution paths and we don't want to touch them.
-				if (mesh_type != 0) continue;
-				if (name_hash == 0) continue;
-
+				uint32_t old_handle = gmd.texture_handle;
 				uint32_t new_handle = 0;
-				GetTexture(nullptr, &new_handle, name_hash);
-				*(uint32_t*)(gmd + 0x44) = new_handle;
+				GetTexture(nullptr, &new_handle, gmd.texture_name_hash);
+				gmd.texture_handle = new_handle;
 
-				LOG(INFO) << "populate_entry_textures: '" << entry << "' mesh[" << i << "]"
-				          << " name_hash=" << name_hash
-				          << " handle 0x" << std::hex << old_handle << " -> 0x" << new_handle << std::dec;
+				LOG(INFO) << "draw_populate_entry_textures: '" << entry << "' mesh[" << i << "]"
+				          << " name_hash=" << gmd.texture_name_hash
+				          << " handle 0x" << std::hex << old_handle
+				          << " -> 0x" << new_handle << std::dec;
 				populated++;
 			}
-			LOG(INFO) << "populate_entry_textures: '" << entry << "' populated " << populated << " handle(s)";
+			LOG(INFO) << "draw_populate_entry_textures: '" << entry
+			          << "' populated " << populated << " handle(s)";
 			return populated;
 		});
 
 		// Lua API: Function
 		// Table: data
-		// Name: set_mesh_visible
+		// Name: draw_set_mesh_visible
 		// Param: entry_name: string: Model entry (e.g. "HecateHub_Mesh").
 		// Param: mesh_name: string: Mesh name inside that entry (e.g. "TorusHubMesh").
 		// Param: visible: boolean: true to show, false to hide.
 		// Returns: boolean — true on success.
-		//
-		// Finer-grained than set_draw_visible (which hides the whole entry):
-		// walks the entry's GrannyMeshData vector, finds the mesh whose
-		// mesh-name hash at GMD+0x48 matches `mesh_name`, and flips its
-		// texture-name hash at GMD+0x40 between 0 (hide) and the original
-		// value (show).
-		//
-		// Hide path uses DoDraw3D's OWN mesh-type switch: setting
-		// GMD+0x4C = 2 makes the main-draw function skip to
-		// next-iteration at 0x1401ebd25 — no cmdDrawIndexed is issued,
-		// no texture lookup attempted.  This is the same branch the
-		// engine takes for its own shadow meshes (they're drawn via
-		// DoDrawShadow3D instead, which our accessory meshes don't
-		// have a shadow entry in, so they stay hidden everywhere).
-		// No DX12 validation errors, no command-list poisoning.
-		//
-		// Used for instant accessory toggle: mesh_add mods merge their
-		// meshes INTO stock entries, so the entry-level draw-gate would
-		// hide the body alongside the accessory.  Per-mesh visibility
-		// keeps the body on and only suppresses the accessory meshes.
-		ns.set_function("set_mesh_visible", [](const std::string& entry,
-		                                        const std::string& mesh_name,
-		                                        bool visible) -> bool {
-			// Saved mesh_type keyed by (entry_hash, mesh_hash, idx).  Index
-			// distinguishes multiple GMDs sharing the same name hash
-			// (e.g. main+outline+shadow variants under a shared name, or
-			// duplicate GLB meshes split by material).  Using raw GMD
-			// pointer would be invalidated if the GMD vector ever
-			// reallocates — unlikely in Hades II's static-load model but
-			// not guaranteed by the engine contract.  std::map so we
-			// don't have to write a tuple hasher.
+		// Finer-grained than draw_set_visible — toggles a single named
+		// mesh inside an entry instead of the whole entry.
+		ns.set_function("draw_set_mesh_visible", [](const std::string& entry,
+		                                             const std::string& mesh_name,
+		                                             bool visible) -> bool {
+			// Saved original mesh_type, keyed by (entry_hash, mesh_hash,
+			// idx).  The tuple key survives GMD vector reallocations —
+			// unlikely in Hades II's static-load model, but free to guard.
 			using SavedKey = std::tuple<uint32_t, uint32_t, size_t>;
 			static std::map<SavedKey, uint8_t> g_saved_mesh_type;
 			static std::mutex g_saved_mutex;
 
 			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
 			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
-			auto mdata_addr = big::hades2_symbol_to_address["sgg::Granny3D::mModelData"];
-			if (!Lookup || !mdata_addr)
+			if (!Lookup)
 			{
-				LOG(ERROR) << "set_mesh_visible: required symbols missing";
+				LOG(ERROR) << "draw_set_mesh_visible: Lookup missing";
 				return false;
 			}
 
@@ -565,66 +635,38 @@ namespace lua::hades::draw
 			Lookup(&entry_guid, entry.c_str(), entry.size());
 			if (!entry_guid.mId)
 			{
-				LOG(WARNING) << "set_mesh_visible: entry hash=0 for '" << entry << "'";
+				LOG(WARNING) << "draw_set_mesh_visible: entry hash=0 for '" << entry << "'";
 				return false;
 			}
 			sgg::HashGuid mesh_guid{};
 			Lookup(&mesh_guid, mesh_name.c_str(), mesh_name.size());
 			if (!mesh_guid.mId)
 			{
-				LOG(WARNING) << "set_mesh_visible: mesh hash=0 for '" << mesh_name << "'";
+				LOG(WARNING) << "draw_set_mesh_visible: mesh hash=0 for '" << mesh_name << "'";
 				return false;
 			}
 
-			uint8_t* mdata = mdata_addr.as<uint8_t*>();
-			void* buckets_ptr = nullptr;
-			uint64_t bucket_count = 0;
-			if (!safe_read_ptr(mdata + 0x08, &buckets_ptr)) return false;
-			if (!safe_read_u64(mdata + 0x10, &bucket_count)) return false;
-			if (!buckets_ptr || !bucket_count || bucket_count > 0x100000) return false;
-
-			uint32_t h = entry_guid.mId;
-			h = ((h >> 16) ^ h) * 0x7feb352d;
-			h = ((h >> 15) ^ h) * 0x846ca68b;
-			h = (h >> 16) ^ h;
-			uint8_t* node = (uint8_t*)((void**)buckets_ptr)[h % bucket_count];
-			int walk_guard = 0;
-			while (node && walk_guard++ < 32)
+			ModelDataNode* node = find_model_data_node(entry_guid.mId);
+			if (!node)
 			{
-				uint32_t id = 0;
-				if (!safe_read_u32(node, &id)) return false;
-				if (id == entry_guid.mId) break;
-				void* nxt = nullptr;
-				if (!safe_read_ptr(node + 0xC0, &nxt)) return false;
-				node = (uint8_t*)nxt;
-			}
-			if (!node || walk_guard >= 32)
-			{
-				LOG(WARNING) << "set_mesh_visible: entry '" << entry << "' not in mModelData";
+				LOG(WARNING) << "draw_set_mesh_visible: entry '" << entry << "' not in mModelData";
 				return false;
 			}
 
-			void* vb_p = nullptr; void* ve_p = nullptr;
-			if (!safe_read_ptr(node + 0x10, &vb_p)) return false;
-			if (!safe_read_ptr(node + 0x18, &ve_p)) return false;
-			uint8_t* vec_begin = (uint8_t*)vb_p;
-			uint8_t* vec_end   = (uint8_t*)ve_p;
-			size_t mesh_count = (vec_end >= vec_begin) ? (size_t)(vec_end - vec_begin) / 0x50 : 0;
-			if (mesh_count == 0 || mesh_count > 128) return false;
+			GrannyMeshData* meshes = nullptr;
+			size_t mesh_count = 0;
+			if (!get_entry_meshes(node, &meshes, &mesh_count)) return false;
 
-			// Sentinel byte used for hidden state (= shadow mesh type,
-			// which DoDraw3D skips to next-iteration).
-			constexpr uint8_t HIDE_TYPE = 2;
 			int matched = 0;
 			std::lock_guard lk(g_saved_mutex);
 			for (size_t i = 0; i < mesh_count; i++)
 			{
-				uint8_t* gmd = vec_begin + i * 0x50;
+				GrannyMeshData& gmd = meshes[i];
 				uint32_t gmd_mesh_hash = 0;
-				if (!safe_read_u32(gmd + 0x48, &gmd_mesh_hash)) continue;
+				if (!safe_read_u32(&gmd.mesh_name_hash, &gmd_mesh_hash)) continue;
 				if (gmd_mesh_hash != mesh_guid.mId) continue;
 
-				uint8_t current_type = *(uint8_t*)(gmd + 0x4C);
+				uint8_t current_type = gmd.mesh_type;
 				SavedKey key{entry_guid.mId, mesh_guid.mId, i};
 
 				if (visible)
@@ -632,31 +674,31 @@ namespace lua::hades::draw
 					auto it = g_saved_mesh_type.find(key);
 					if (it != g_saved_mesh_type.end())
 					{
-						*(uint8_t*)(gmd + 0x4C) = it->second;
+						gmd.mesh_type = it->second;
 						g_saved_mesh_type.erase(it);
 					}
 					// else: already visible — no-op
 				}
 				else
 				{
-					if (current_type != HIDE_TYPE && !g_saved_mesh_type.count(key))
+					if (current_type != kMeshTypeHidden && !g_saved_mesh_type.count(key))
 					{
 						g_saved_mesh_type[key] = current_type;
-						*(uint8_t*)(gmd + 0x4C) = HIDE_TYPE;
+						gmd.mesh_type = kMeshTypeHidden;
 					}
 					// else: already hidden — no-op
 				}
 				matched++;
-				// Don't break: continue so main+outline+shadow variants
-				// with the same mesh-name hash all get toggled together.
+				// Don't break: toggle main+outline+shadow variants sharing
+				// the same mesh-name hash together.
 			}
 			if (matched == 0)
 			{
-				LOG(WARNING) << "set_mesh_visible: mesh '" << mesh_name
+				LOG(WARNING) << "draw_set_mesh_visible: mesh '" << mesh_name
 				             << "' not in entry '" << entry << "'";
 				return false;
 			}
-			LOG(INFO) << "set_mesh_visible: " << entry << "/" << mesh_name
+			LOG(INFO) << "draw_set_mesh_visible: " << entry << "/" << mesh_name
 			          << " -> " << (visible ? "show" : "hide")
 			          << " (" << matched << " mesh" << (matched > 1 ? "es" : "") << ")";
 			return true;
@@ -664,54 +706,40 @@ namespace lua::hades::draw
 
 		// Lua API: Function
 		// Table: data
-		// Name: swap_to_variant
+		// Name: draw_swap_to_variant
 		// Param: stock_entry: string: Stock entry name (e.g. "HecateHub_Mesh").
 		// Param: variant_entry: string: Variant entry name loaded in mModelData.
 		// Returns: boolean — true on success.
-		//
-		// One-call atomic outfit switch, matching the engine's own rendering
-		// architecture:
-		//   1. Populate the variant's GMD+0x44 via sgg::GameAssetManager::GetTexture
-		//      (mirrors what ModelAnimation::PrepDraw does for stock entries).
-		//   2. Install a hash remap so draw commands using `stock_entry` get
-		//      redirected to the variant entry at dispatch time.
-		//
-		// Variant textures resolve through the variant's own `GMD+0x40`
-		// (texture name hashes written by AddModelData).  No vcount/topology
-		// constraints; stock state is never mutated.
+		// Redirects draw calls for `stock_entry` to `variant_entry`.
+		// Use draw_populate_entry_textures on the variant first (ideally
+		// from a safe window like the first ImGui frame) — this call is a
+		// cheap map write and is not safe to call GetTexture from.
 		//
 		// **Example Usage:**
 		// ```lua
-		// rom.data.swap_to_variant("HecateHub_Mesh", "HecateHub_Variant_Mesh")
+		// rom.data.draw_populate_entry_textures("HecateHub_Variant_Mesh")
+		// rom.data.draw_swap_to_variant("HecateHub_Mesh", "HecateHub_Variant_Mesh")
 		// -- later:
-		// rom.data.restore_stock("HecateHub_Mesh")
+		// rom.data.draw_restore_stock("HecateHub_Mesh")
 		// ```
-		ns.set_function("swap_to_variant", [](const std::string& stock_entry,
-		                                       const std::string& variant_entry) -> bool {
-			// Just install the hash remap.  Texture handles (GMD+0x44) must be
-			// populated ahead of time via populate_entry_textures at a known-safe
-			// window (first ImGui frame, after LoadAllModelAndAnimationData).
-			// Calling GetTexture from the render-thread ImGui callback while the
-			// game thread is actively rendering the target entry deadlocks the
-			// render pipeline (observed: "Waiting for RenderCommands to be ready
-			// to write").  Keeping this path to a single atomic map write makes
-			// swaps cheap and thread-safe.
+		ns.set_function("draw_swap_to_variant", [](const std::string& stock_entry,
+		                                            const std::string& variant_entry) -> bool {
 			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
 			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
-			if (!Lookup) { LOG(ERROR) << "swap_to_variant: Lookup missing"; return false; }
+			if (!Lookup) { LOG(ERROR) << "draw_swap_to_variant: Lookup missing"; return false; }
 
 			sgg::HashGuid variant_guid{};
 			Lookup(&variant_guid, variant_entry.c_str(), variant_entry.size());
 			if (!variant_guid.mId)
 			{
-				LOG(WARNING) << "swap_to_variant: variant hash=0 ('" << variant_entry << "')";
+				LOG(WARNING) << "draw_swap_to_variant: variant hash=0 ('" << variant_entry << "')";
 				return false;
 			}
 			sgg::HashGuid stock_guid{};
 			Lookup(&stock_guid, stock_entry.c_str(), stock_entry.size());
 			if (!stock_guid.mId)
 			{
-				LOG(WARNING) << "swap_to_variant: stock hash=0 ('" << stock_entry << "')";
+				LOG(WARNING) << "draw_swap_to_variant: stock hash=0 ('" << stock_entry << "')";
 				return false;
 			}
 
@@ -721,26 +749,24 @@ namespace lua::hades::draw
 			}
 			update_active_flag();
 
-			LOG(INFO) << "swap_to_variant: '" << stock_entry << "' -> '" << variant_entry << "'";
+			LOG(INFO) << "draw_swap_to_variant: '" << stock_entry << "' -> '" << variant_entry << "'";
 			return true;
 		});
 
 		// Lua API: Function
 		// Table: data
-		// Name: restore_stock
+		// Name: draw_restore_stock
 		// Param: stock_entry: string: Stock entry name to revert to.
 		// Returns: boolean — true on success.
-		// Clears any active hash remap for the given stock entry.  No-op if no
-		// remap is active.  Populated variant GMD+0x44 handles are left in place
-		// (they're harmless — only used when a remap is active).
-		ns.set_function("restore_stock", [](const std::string& stock_entry) -> bool {
+		// Clears any active hash remap for the given stock entry.
+		ns.set_function("draw_restore_stock", [](const std::string& stock_entry) -> bool {
 			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
 			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
 			sgg::HashGuid stock{};
 			Lookup(&stock, stock_entry.c_str(), stock_entry.size());
 			if (!stock.mId)
 			{
-				LOG(WARNING) << "restore_stock: hash=0 ('" << stock_entry << "')";
+				LOG(WARNING) << "draw_restore_stock: hash=0 ('" << stock_entry << "')";
 				return false;
 			}
 			{
@@ -748,7 +774,7 @@ namespace lua::hades::draw
 				g_remap.erase(stock.mId);
 			}
 			update_active_flag();
-			LOG(INFO) << "restore_stock: '" << stock_entry << "' remap cleared";
+			LOG(INFO) << "draw_restore_stock: '" << stock_entry << "' remap cleared";
 			return true;
 		});
 

--- a/src/lua_extensions/bindings/hades/draw.cpp
+++ b/src/lua_extensions/bindings/hades/draw.cpp
@@ -1,0 +1,416 @@
+/// @file draw.cpp
+/// @brief Draw-call control for 3D model entries.
+///
+/// Lua-driven draw-path control.  Current bindings:
+///
+///   rom.data.set_draw_visible(entry, visible)
+///     Show/hide an entire entry across all draw passes.
+///
+///   rom.data.dump_pool_stats()
+///     Diagnostic: log vertex/index pool cursor + capacity per
+///     shader effect.
+///
+/// Hooks DoDraw3D / DoDrawShadow3D / DoDraw3DThumbnail (share the
+/// `static void(const vector<RenderMesh*>&, uint, int, HashGuid)`
+/// signature) with standard detours.  DoDrawShadowCast3D has a
+/// different signature (no HashGuid); it's handled via a code cave
+/// below.
+
+#include "draw.hpp"
+
+#include "hades_ida.hpp"
+
+#include <hades2/pdb_symbol_map.hpp>
+#include <hooks/hooking.hpp>
+#include <lua/lua_manager.hpp>
+#include <memory/gm_address.hpp>
+#include <mutex>
+#include <shared_mutex>
+#include <string/string.hpp>
+
+namespace lua::hades::draw
+{
+	// ─── State ─────────────────────────────────────────────────────────
+
+	static std::shared_mutex g_mutex;
+	static std::unordered_set<unsigned int> g_hidden_entries;
+
+	// Fast-path flag for the code cave — avoids the function-call overhead
+	// on every draw entry when nothing is hidden.
+	static volatile uint8_t g_any_active = 0;
+
+	static void update_active_flag()
+	{
+		g_any_active = g_hidden_entries.empty() ? 0 : 1;
+	}
+
+	// Called from the code cave via function pointer.
+	// Returns: 0 = pass through, 1 = hidden (skip).  The *out_hash
+	// parameter is reserved so the cave's ABI stays stable if a later
+	// change adds a remap path (return 2 + *out_hash set).
+	static int check_draw_entry(uint32_t hash, uint32_t* /*out_hash*/)
+	{
+		std::shared_lock l(g_mutex);
+		if (g_hidden_entries.count(hash))
+			return 1;
+		return 0;
+	}
+
+	// ─── Detour hooks (DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail) ──
+	// Each hook checks the hidden-set and skips the iteration if its
+	// entry is hidden.  DoDrawShadowCast3D has a different signature
+	// (no HashGuid parameter), so it's handled via a code cave below.
+
+	static void hook_DoDraw3D(void* vec_ref, unsigned int index, int param, sgg::HashGuid hash)
+	{
+		{
+			std::shared_lock l(g_mutex);
+			if (g_hidden_entries.count(hash.mId))
+				return;
+		}
+		big::g_hooking->get_original<hook_DoDraw3D>()(vec_ref, index, param, hash);
+	}
+
+	static void hook_DoDrawShadow3D(void* vec_ref, unsigned int index, int param, sgg::HashGuid hash)
+	{
+		{
+			std::shared_lock l(g_mutex);
+			if (g_hidden_entries.count(hash.mId))
+				return;
+		}
+		big::g_hooking->get_original<hook_DoDrawShadow3D>()(vec_ref, index, param, hash);
+	}
+
+	static void hook_DoDraw3DThumbnail(void* vec_ref, unsigned int index, int param, sgg::HashGuid hash)
+	{
+		{
+			std::shared_lock l(g_mutex);
+			if (g_hidden_entries.count(hash.mId))
+				return;
+		}
+		big::g_hooking->get_original<hook_DoDraw3DThumbnail>()(vec_ref, index, param, hash);
+	}
+
+	// ─── Code cave for DoDrawShadowCast3D ─────────────────────────────
+	//
+	// Overwrites 7 bytes at the dispatch's shadow-flag check:
+	//   cmp byte [r10+0x2d], 0   (5B)
+	//   je  <main_path>          (2B)
+	// with:
+	//   jmp code_cave            (5B)
+	//   nop; nop                 (2B)
+	//
+	// The cave checks [r10+0x28] against the hidden set.  If hidden it
+	// skips to the loop-next target; otherwise it replays the original
+	// cmp+je and resumes normal execution.
+
+	static void install_shadow_cast_patch(uintptr_t doDraw3D_addr)
+	{
+		// All offsets are relative to the DoDraw3D PDB symbol address.
+		uintptr_t patch_site      = doDraw3D_addr + 0x148E4; // cmp byte [r10+0x2d], 0
+		uintptr_t shadow_continue = doDraw3D_addr + 0x148EB; // shadow param setup
+		uintptr_t main_continue   = doDraw3D_addr + 0x148FF; // hash load + main path
+		uintptr_t loop_next       = doDraw3D_addr + 0x14AC1; // inc rsi (loop next)
+
+		// Verify expected bytes before patching.
+		const uint8_t expected[] = {0x41, 0x80, 0x7A, 0x2D, 0x00, 0x74, 0x14};
+		if (memcmp((void*)patch_site, expected, 7) != 0)
+		{
+			LOG(ERROR) << "draw: shadow patch byte mismatch at "
+			           << HEX_TO_UPPER(patch_site) << " — skipping";
+			return;
+		}
+
+		// Allocate code cave within ±2GB of the patch site (required for rel32 jmp).
+		void* cave = nullptr;
+		uintptr_t try_addr = patch_site & ~0xFFFFULL;
+		for (uintptr_t offset = 0x10000; offset < 0x7FFF0000ULL; offset += 0x10000)
+		{
+			cave = VirtualAlloc((void*)(try_addr - offset), 4096,
+			                    MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+			if (cave) break;
+			cave = VirtualAlloc((void*)(try_addr + offset), 4096,
+			                    MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+			if (cave) break;
+		}
+		if (!cave)
+		{
+			LOG(ERROR) << "draw: VirtualAlloc failed for shadow code cave";
+			return;
+		}
+
+		uintptr_t cave_addr = (uintptr_t)cave;
+		uintptr_t data_base = cave_addr + 0x80; // data section after code
+
+		// Data section (5 pointers, filled at runtime)
+		*(uintptr_t*)(data_base + 0x00) = (uintptr_t)&g_any_active;
+		*(uintptr_t*)(data_base + 0x08) = (uintptr_t)&check_draw_entry;
+		*(uintptr_t*)(data_base + 0x10) = shadow_continue;
+		*(uintptr_t*)(data_base + 0x18) = main_continue;
+		*(uintptr_t*)(data_base + 0x20) = loop_next;
+
+		// Code section — hand-assembled x86-64
+		uint8_t* p = (uint8_t*)cave;
+		auto emit = [&](std::initializer_list<uint8_t> bytes) {
+			for (auto b : bytes) *p++ = b;
+		};
+		auto emit_rel32 = [&](int32_t disp) {
+			memcpy(p, &disp, 4); p += 4;
+		};
+		auto cur = [&]() -> size_t { return (size_t)(p - (uint8_t*)cave); };
+		auto rip_data = [&](size_t data_off, size_t rest) -> int32_t {
+			return (int32_t)((data_base + data_off) - ((uintptr_t)p + rest));
+		};
+
+		// Fast path: if nothing is active (no hidden, no remap), skip to original
+		emit({0x48, 0x8B, 0x05}); emit_rel32(rip_data(0x00, 4)); // mov rax, [rip+g_any_active]
+		emit({0x80, 0x38, 0x00});                                  // cmp byte [rax], 0
+		emit({0x74}); size_t je_fast = cur(); emit({0x00});         // je .not_hidden
+
+		// Slow path: call check_draw_entry(ecx=hash, rdx=&out_hash)
+		// Returns: eax=0 pass, eax=1 hidden, eax=2 remapped
+		emit({0x51, 0x52});                                         // push rcx; push rdx
+		emit({0x48, 0x83, 0xEC, 0x30});                             // sub rsp, 0x30 (shadow + local)
+		emit({0x41, 0x8B, 0x4A, 0x28});                             // mov ecx, [r10+0x28]
+		emit({0x48, 0x8D, 0x54, 0x24, 0x28});                      // lea rdx, [rsp+0x28] (out_hash)
+		emit({0x48, 0x8B, 0x05}); emit_rel32(rip_data(0x08, 4));   // mov rax, [rip+check_draw_entry]
+		emit({0xFF, 0xD0});                                         // call rax
+		emit({0x83, 0xF8, 0x01});                                   // cmp eax, 1
+		emit({0x74}); size_t je_skip = cur(); emit({0x00});          // je .skip
+		emit({0x83, 0xF8, 0x02});                                   // cmp eax, 2
+		emit({0x74}); size_t je_remap = cur(); emit({0x00});         // je .remap
+		// eax=0: pass through
+		emit({0x48, 0x83, 0xC4, 0x30});                             // add rsp, 0x30
+		emit({0x5A, 0x59});                                         // pop rdx; pop rcx
+		emit({0xEB}); size_t jmp_not_hidden = cur(); emit({0x00});   // jmp .not_hidden
+
+		// .remap — rewrite [r10+0x28] with remapped hash, then pass through
+		size_t remap_off = cur();
+		*((uint8_t*)cave + je_remap) = (uint8_t)(remap_off - je_remap - 1);
+		emit({0x8B, 0x44, 0x24, 0x28});                             // mov eax, [rsp+0x28] (out_hash)
+		emit({0x41, 0x89, 0x42, 0x28});                             // mov [r10+0x28], eax (overwrite!)
+		emit({0x48, 0x83, 0xC4, 0x30});                             // add rsp, 0x30
+		emit({0x5A, 0x59});                                         // pop rdx; pop rcx
+		emit({0xEB}); size_t jmp_not_hidden2 = cur(); emit({0x00});  // jmp .not_hidden
+
+		// .not_hidden — replay original instructions
+		size_t not_hidden = cur();
+		*((uint8_t*)cave + je_fast) = (uint8_t)(not_hidden - je_fast - 1);
+		*((uint8_t*)cave + jmp_not_hidden) = (uint8_t)(not_hidden - jmp_not_hidden - 1);
+		*((uint8_t*)cave + jmp_not_hidden2) = (uint8_t)(not_hidden - jmp_not_hidden2 - 1);
+		emit({0x41, 0x80, 0x7A, 0x2D, 0x00});                      // cmp byte [r10+0x2d], 0
+		emit({0x74}); size_t je_main = cur(); emit({0x00});          // je .main
+		emit({0xFF, 0x25}); emit_rel32(rip_data(0x10, 4));          // jmp [shadow_continue]
+
+		// .main — non-shadow path
+		size_t main_off = cur();
+		*((uint8_t*)cave + je_main) = (uint8_t)(main_off - je_main - 1);
+		emit({0xFF, 0x25}); emit_rel32(rip_data(0x18, 4));          // jmp [main_continue]
+
+		// .skip — entry is hidden, advance loop
+		size_t skip_off = cur();
+		*((uint8_t*)cave + je_skip) = (uint8_t)(skip_off - je_skip - 1);
+		emit({0x48, 0x83, 0xC4, 0x30});                             // add rsp, 0x30
+		emit({0x5A, 0x59});                                         // pop rdx; pop rcx
+		emit({0xFF, 0x25}); emit_rel32(rip_data(0x20, 4));          // jmp [loop_next]
+
+		LOG(INFO) << "draw: shadow cave at " << HEX_TO_UPPER(cave_addr)
+		          << " (" << cur() << " bytes)";
+
+		// Overwrite the original 7 bytes with jmp + nops.
+		DWORD old_protect;
+		VirtualProtect((void*)patch_site, 7, PAGE_EXECUTE_READWRITE, &old_protect);
+		int32_t rel = (int32_t)(cave_addr - (patch_site + 5));
+		uint8_t patch[] = {0xE9, 0, 0, 0, 0, 0x90, 0x90};
+		memcpy(patch + 1, &rel, 4);
+		memcpy((void*)patch_site, patch, 7);
+		VirtualProtect((void*)patch_site, 7, old_protect, &old_protect);
+		FlushInstructionCache(GetCurrentProcess(), (void*)patch_site, 7);
+
+		LOG(INFO) << "draw: shadow patch installed at " << HEX_TO_UPPER(patch_site);
+	}
+
+	// ─── Lua binding ──────────────────────────────────────────────────
+
+	// Lua API: Function
+	// Table: data
+	// Name: set_draw_visible
+	// Param: entry_name: string: Model entry name (e.g. "HecateBattle_Mesh").
+	// Param: visible: boolean: true to show, false to hide.
+	// Toggles visibility of a model entry by suppressing its draw calls
+	// (DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail, DoDrawShadowCast3D).
+	// Takes effect immediately — no rebuild, no restart, no data mutation.
+	//
+	// **Example Usage:**
+	// ```lua
+	// rom.data.set_draw_visible("HecateBattle_Mesh", false)
+	// ```
+	static void set_draw_visible(const std::string& entry_name, bool visible)
+	{
+		static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
+		    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
+
+		sgg::HashGuid guid{};
+		Lookup(&guid, entry_name.c_str(), entry_name.size());
+
+		if (guid.mId == 0)
+		{
+			LOG(WARNING) << "draw: hash=0 for '" << entry_name
+			             << "' — hash system not ready, skipping";
+			return;
+		}
+
+		size_t old_size, new_size;
+		{
+			std::unique_lock l(g_mutex);
+			old_size = g_hidden_entries.size();
+			if (visible)
+				g_hidden_entries.erase(guid.mId);
+			else
+				g_hidden_entries.insert(guid.mId);
+			new_size = g_hidden_entries.size();
+		}
+
+		update_active_flag();
+
+		LOG(INFO) << "draw: " << entry_name
+		          << (visible ? " SHOW" : " HIDE")
+		          << " (hash=" << guid.mId
+		          << ", set " << old_size << " -> " << new_size << ")";
+	}
+
+	// ─── SEH-protected pointer reads ──────────────────────────────────
+	// populate_entry_textures / set_mesh_visible / swap_to_variant walk
+	// the game's mModelData hash-bucket structure via raw pointers.  Any
+	// step can fault if the layout shifts after a game update; these
+	// helpers let callers detect and log a fault instead of crashing.
+	// Plain C (no C++ objects) so __try / __except are legal.
+	static int __stdcall safe_read_u64(const void* addr, uint64_t* out_val)
+	{
+		__try { *out_val = *(const uint64_t*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	static int __stdcall safe_read_u32(const void* addr, uint32_t* out_val)
+	{
+		__try { *out_val = *(const uint32_t*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	static int __stdcall safe_read_ptr(const void* addr, void** out_val)
+	{
+		__try { *out_val = *(void* const*)addr; return 1; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	// ─── Registration ─────────────────────────────────────────────────
+
+	void bind(sol::state_view& state, sol::table& lua_ext)
+	{
+		auto ns = lua_ext["data"].get_or_create<sol::table>();
+		ns.set_function("set_draw_visible", set_draw_visible);
+
+		// Lua API: Function
+		// Table: data
+		// Name: dump_pool_stats
+		// Returns: integer — number of per-shader vertex buffers dumped.
+		// Walks sgg::gStaticDrawBuffers and logs each shader-effect's
+		// vertex pool: total capacity (Buffer.mSize &0xFFFFFFFF at +0x38),
+		// cursor (+0x40 of ForgeGeometryBuffers — next-free vertex slot),
+		// stride (from gShaderEffects[i].+0x95c).  Also logs the single
+		// global gStaticIndexBuffers cursor + size.
+		ns.set_function("dump_pool_stats", []() -> int {
+			auto draw_buf_vec = big::hades2_symbol_to_address["sgg::gStaticDrawBuffers"];
+			auto idx_buf_ptr  = big::hades2_symbol_to_address["sgg::gStaticIndexBuffers"];
+			auto idx_off_ptr  = big::hades2_symbol_to_address["sgg::gStaticIndexBufferOffset"];
+			auto shader_effects = big::hades2_symbol_to_address["sgg::gShaderEffects"];
+			if (!draw_buf_vec || !idx_buf_ptr || !idx_off_ptr || !shader_effects)
+			{
+				LOG(ERROR) << "dump_pool_stats: symbols missing";
+				return 0;
+			}
+			auto vec = draw_buf_vec.as<uint8_t *>();
+			auto vec_begin = *(uint8_t **)(vec + 0x00);
+			auto vec_end   = *(uint8_t **)(vec + 0x08);
+			size_t count = (vec_end - vec_begin) / 72;
+			LOG(INFO) << "=== Static vertex pool stats (" << count << " geo buffers) ===";
+			// The shader→geo mapping isn't 1:1 (addShaderEffect calls
+			// addStaticVertexBuffers twice with different sizes per effect),
+			// so deriving the real per-shader byte stride from the geo
+			// index alone is wrong.  Instead, report raw cursor + capacity,
+			// plus a rough estimate at the common 40 B character-vertex
+			// stride.  Only the raw cursor / capacity should be trusted.
+			int logged = 0;
+			for (size_t i = 0; i < count && i < 128; ++i)
+			{
+				uint8_t *geo = vec_begin + i * 72;
+				uint8_t *buf = *(uint8_t **)(geo + 0x20);
+				if (!buf) continue;
+				uint32_t cursor = *(uint32_t *)(geo + 0x40);
+				uint64_t msize_raw = *(uint64_t *)(buf + 0x38);
+				uint32_t msize = (uint32_t)msize_raw;
+				double cap_mb = msize / (1024.0 * 1024.0);
+				double est_mb = (uint64_t)cursor * 40 / (1024.0 * 1024.0);
+				LOG(INFO) << "  geo[" << i << "]: capacity=" << cap_mb
+				          << " MB  cursor=" << cursor << " verts (~"
+				          << est_mb << " MB @ 40B/vert)";
+				logged++;
+			}
+			// Index buffer uses fixed 2-byte stride — bounds check is
+			// exact, so this % is reliable (unlike the vertex-pool one).
+			uint8_t *ibuf = *idx_buf_ptr.as<uint8_t **>();
+			uint32_t ioff = *idx_off_ptr.as<uint32_t *>();
+			if (ibuf)
+			{
+				uint64_t imsize_raw = *(uint64_t *)(ibuf + 0x38);
+				uint32_t imsize = (uint32_t)imsize_raw;
+				uint64_t iused = (uint64_t)ioff * 2;
+				double ipct = imsize ? (100.0 * iused / imsize) : 0.0;
+				LOG(INFO) << "  index buf: " << (iused / (1024.0 * 1024.0)) << " MB / "
+				          << (imsize / (1024.0 * 1024.0)) << " MB (" << ipct << "%)";
+			}
+			return logged;
+		});
+
+		// NOTE: No hook on LoadAllModelAndAnimationData — a second detour
+		// are loaded automatically by the game when add_granny_file exposes
+		// them.  The double-hook was causing weapon model corruption.
+
+		// Detour hooks on DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail.
+		{
+			auto addr = big::hades2_symbol_to_address["sgg::DrawManager::DoDraw3D"];
+			if (addr)
+			{
+				static auto hook_ = big::hooking::detour_hook_helper::add<hook_DoDraw3D>(
+				    "drawDoDraw3D", addr);
+				LOG(INFO) << "draw: hooked DoDraw3D";
+			}
+		}
+		{
+			auto addr = big::hades2_symbol_to_address["sgg::DrawManager::DoDrawShadow3D"];
+			if (addr)
+			{
+				static auto hook_ = big::hooking::detour_hook_helper::add<hook_DoDrawShadow3D>(
+				    "drawDoDrawShadow3D", addr);
+				LOG(INFO) << "draw: hooked DoDrawShadow3D";
+			}
+		}
+		{
+			auto addr = big::hades2_symbol_to_address["sgg::DrawManager::DoDraw3DThumbnail"];
+			if (addr)
+			{
+				static auto hook_ = big::hooking::detour_hook_helper::add<hook_DoDraw3DThumbnail>(
+				    "drawDoDraw3DThumbnail", addr);
+				LOG(INFO) << "draw: hooked DoDraw3DThumbnail";
+			}
+		}
+
+		// Manual code cave for DoDrawShadowCast3D.
+		{
+			auto addr = big::hades2_symbol_to_address["sgg::DrawManager::DoDraw3D"];
+			if (addr)
+				install_shadow_cast_patch(addr.as<uintptr_t>());
+		}
+	}
+
+} // namespace lua::hades::draw

--- a/src/lua_extensions/bindings/hades/draw.cpp
+++ b/src/lua_extensions/bindings/hades/draw.cpp
@@ -1,13 +1,24 @@
 /// @file draw.cpp
 /// @brief Draw-call control for 3D model entries.
 ///
-/// Lua-driven draw-path control.  Current bindings:
+/// Provides Lua APIs for controlling 3D model rendering at runtime:
 ///
 ///   rom.data.set_draw_visible(entry, visible)
 ///     Show/hide an entire entry across all draw passes.
 ///
 ///   rom.data.set_mesh_visible(entry, mesh_name, visible)
 ///     Show/hide a single mesh inside an entry.
+///
+///   rom.data.swap_to_variant(stock, variant)
+///   rom.data.restore_stock(stock)
+///     Redirect a stock entry's draw calls to a variant entry.
+///     Enables outfit switching without reload.  swap_to_variant
+///     pre-populates the variant's texture handles before installing
+///     the remap so the first swapped frame renders correctly.
+///
+///   rom.data.populate_entry_textures(entry)
+///     Pre-populate an entry's texture handles without remapping.
+///     Useful for variant entries the scene isn't actively rendering.
 ///
 ///   rom.data.dump_pool_stats()
 ///     Diagnostic: log vertex/index pool cursor + capacity per
@@ -16,8 +27,9 @@
 /// Hooks DoDraw3D / DoDrawShadow3D / DoDraw3DThumbnail (share the
 /// `static void(const vector<RenderMesh*>&, uint, int, HashGuid)`
 /// signature) with standard detours.  DoDrawShadowCast3D has a
-/// different signature (no HashGuid); it's handled via a code cave
-/// below.
+/// different signature (no HashGuid) so its remap would need a
+/// code-cave approach not included here — it participates in the
+/// hidden-set but not in hash remap.
 
 #include "draw.hpp"
 
@@ -26,12 +38,14 @@
 #include <hades2/pdb_symbol_map.hpp>
 #include <hooks/hooking.hpp>
 #include <lua/lua_manager.hpp>
+#include <atomic>
 #include <map>
 #include <memory/gm_address.hpp>
 #include <mutex>
 #include <shared_mutex>
 #include <string/string.hpp>
 #include <tuple>
+#include <unordered_map>
 
 namespace lua::hades::draw
 {
@@ -39,43 +53,63 @@ namespace lua::hades::draw
 
 	static std::shared_mutex g_mutex;
 	static std::unordered_set<unsigned int> g_hidden_entries;
+	static std::unordered_map<unsigned int, unsigned int> g_remap; // original → variant
 
 	// Fast-path flag for the code cave — avoids the function-call overhead
-	// on every draw entry when nothing is hidden.
+	// on every draw entry when nothing is active (hidden or remapped).
 	static volatile uint8_t g_any_active = 0;
 
 	static void update_active_flag()
 	{
-		g_any_active = g_hidden_entries.empty() ? 0 : 1;
+		g_any_active = (g_hidden_entries.empty() && g_remap.empty()) ? 0 : 1;
 	}
 
 	// Called from the code cave via function pointer.
-	// Returns: 0 = pass through, 1 = hidden (skip).  The *out_hash
-	// parameter is reserved so the cave's ABI stays stable if a later
-	// change adds a remap path (return 2 + *out_hash set).
-	static int check_draw_entry(uint32_t hash, uint32_t* /*out_hash*/)
+	// Returns: 0 = pass through, 1 = hidden (skip), 2 = remapped (*out_hash set)
+	static int check_draw_entry(uint32_t hash, uint32_t* out_hash)
 	{
 		std::shared_lock l(g_mutex);
+		auto it = g_remap.find(hash);
+		if (it != g_remap.end())
+		{
+			*out_hash = it->second;
+			return 2;
+		}
 		if (g_hidden_entries.count(hash))
 			return 1;
 		return 0;
 	}
 
 	// ─── Detour hooks (DoDraw3D, DoDrawShadow3D, DoDraw3DThumbnail) ──
-	// Each hook checks the hidden-set and skips the iteration if its
-	// entry is hidden.  DoDrawShadowCast3D has a different signature
-	// (no HashGuid parameter), so it's handled via a code cave below.
+	// Each hook inlines its own remap + hidden-set check.  Main-pass
+	// DoDraw3D participates in both; shadow and thumbnail paths honour
+	// the hidden-set for visibility-gate parity but skip the remap —
+	// DoDrawShadowCast3D has a different signature (no HashGuid
+	// parameter), so its remap would need a code-cave approach not
+	// included here.
 
 	static void hook_DoDraw3D(void* vec_ref, unsigned int index, int param, sgg::HashGuid hash)
 	{
 		{
 			std::shared_lock l(g_mutex);
+			auto it = g_remap.find(hash.mId);
+			if (it != g_remap.end())
+				hash.mId = it->second;
 			if (g_hidden_entries.count(hash.mId))
 				return;
 		}
 		big::g_hooking->get_original<hook_DoDraw3D>()(vec_ref, index, param, hash);
 	}
 
+	// Shadow + thumbnail paths honour the hidden-set but do NOT
+	// participate in hash remap.  Reason: DoDrawShadowCast3D has a
+	// different signature (no HashGuid param) so its remap would need
+	// a code-cave approach we don't ship here.  Remapping the other
+	// shadow paths while ShadowCast stays stock leaves the engine with
+	// inconsistent per-entry state (main=variant, shadow_cast=stock,
+	// shadow3D=variant) that appears to wedge the render thread.
+	// Keeping shadow/thumbnail on stock is the safe subset — the main
+	// DoDraw3D swap carries the visual change on its own.
 	static void hook_DoDrawShadow3D(void* vec_ref, unsigned int index, int param, sgg::HashGuid hash)
 	{
 		{
@@ -376,6 +410,106 @@ namespace lua::hades::draw
 			}
 			return logged;
 		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: populate_entry_textures
+		// Param: entry_name: string
+		// Returns: integer — number of textures populated.
+		//
+		// Walks the entry's GrannyMeshData vector and, for each type=0 mesh whose
+		// GMD+0x40 (texture name hash) is non-zero, calls the game's own
+		// sgg::GameAssetManager::GetTexture(hash, &out_handle) and writes the
+		// result into GMD+0x44.  This mimics what ModelAnimation::PrepDraw does
+		// for stock meshes — variants live alongside stock in mModelData but are
+		// never walked by PrepDraw, so their GMD+0x44 stays 0 (→ white rendering
+		// under hash remap).  Calling this once after loading a variant populates
+		// its texture handles so DoDraw3D's fallback path can resolve them.
+		ns.set_function("populate_entry_textures", [](const std::string& entry) -> int {
+			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
+			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
+			static auto GetTexture = big::hades2_symbol_to_address["sgg::GameAssetManager::GetTexture"]
+			    .as_func<void(void*, uint32_t*, uint32_t)>();
+			auto mdata_addr = big::hades2_symbol_to_address["sgg::Granny3D::mModelData"];
+			if (!Lookup || !GetTexture || !mdata_addr)
+			{
+				LOG(ERROR) << "populate_entry_textures: required symbols missing";
+				return 0;
+			}
+
+			sgg::HashGuid guid{};
+			Lookup(&guid, entry.c_str(), entry.size());
+			if (!guid.mId)
+			{
+				LOG(WARNING) << "populate_entry_textures: hash=0 for '" << entry << "'";
+				return 0;
+			}
+
+			uint8_t* mdata = mdata_addr.as<uint8_t*>();
+			void* buckets_ptr = nullptr;
+			uint64_t bucket_count = 0;
+			if (!safe_read_ptr(mdata + 0x08, &buckets_ptr)) return 0;
+			if (!safe_read_u64(mdata + 0x10, &bucket_count)) return 0;
+			if (!buckets_ptr || !bucket_count || bucket_count > 0x100000) return 0;
+
+			uint32_t h = guid.mId;
+			h = ((h >> 16) ^ h) * 0x7feb352d;
+			h = ((h >> 15) ^ h) * 0x846ca68b;
+			h = (h >> 16) ^ h;
+			uint8_t* node = (uint8_t*)((void**)buckets_ptr)[h % bucket_count];
+			int walk_guard = 0;
+			while (node && walk_guard++ < 32)
+			{
+				uint32_t id = 0;
+				if (!safe_read_u32(node, &id)) return 0;
+				if (id == guid.mId) break;
+				void* nxt = nullptr;
+				if (!safe_read_ptr(node + 0xC0, &nxt)) return 0;
+				node = (uint8_t*)nxt;
+			}
+			if (!node || walk_guard >= 32)
+			{
+				LOG(WARNING) << "populate_entry_textures: entry '" << entry << "' not found";
+				return 0;
+			}
+
+			void* vb_p = nullptr; void* ve_p = nullptr;
+			if (!safe_read_ptr(node + 0x10, &vb_p)) return 0;
+			if (!safe_read_ptr(node + 0x18, &ve_p)) return 0;
+			uint8_t* vec_begin = (uint8_t*)vb_p;
+			uint8_t* vec_end   = (uint8_t*)ve_p;
+			size_t mesh_count = (vec_end >= vec_begin) ? (size_t)(vec_end - vec_begin) / 0x50 : 0;
+			if (mesh_count == 0 || mesh_count > 128) return 0;
+
+			int populated = 0;
+			for (size_t i = 0; i < mesh_count; i++)
+			{
+				uint8_t* gmd = vec_begin + i * 0x50;
+
+				uint32_t mesh_type=0, name_hash=0, old_handle=0;
+				safe_read_u32(gmd + 0x4C, &mesh_type);
+				safe_read_u32(gmd + 0x40, &name_hash);
+				safe_read_u32(gmd + 0x44, &old_handle);
+
+				// Game's PrepDraw path only fills GMD+0x44 for type=0 meshes.
+				// Mirror that guard; outlines (type=1) and shadows (type=2)
+				// use different resolution paths and we don't want to touch them.
+				if (mesh_type != 0) continue;
+				if (name_hash == 0) continue;
+
+				uint32_t new_handle = 0;
+				GetTexture(nullptr, &new_handle, name_hash);
+				*(uint32_t*)(gmd + 0x44) = new_handle;
+
+				LOG(INFO) << "populate_entry_textures: '" << entry << "' mesh[" << i << "]"
+				          << " name_hash=" << name_hash
+				          << " handle 0x" << std::hex << old_handle << " -> 0x" << new_handle << std::dec;
+				populated++;
+			}
+			LOG(INFO) << "populate_entry_textures: '" << entry << "' populated " << populated << " handle(s)";
+			return populated;
+		});
+
 		// Lua API: Function
 		// Table: data
 		// Name: set_mesh_visible
@@ -525,6 +659,96 @@ namespace lua::hades::draw
 			LOG(INFO) << "set_mesh_visible: " << entry << "/" << mesh_name
 			          << " -> " << (visible ? "show" : "hide")
 			          << " (" << matched << " mesh" << (matched > 1 ? "es" : "") << ")";
+			return true;
+		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: swap_to_variant
+		// Param: stock_entry: string: Stock entry name (e.g. "HecateHub_Mesh").
+		// Param: variant_entry: string: Variant entry name loaded in mModelData.
+		// Returns: boolean — true on success.
+		//
+		// One-call atomic outfit switch, matching the engine's own rendering
+		// architecture:
+		//   1. Populate the variant's GMD+0x44 via sgg::GameAssetManager::GetTexture
+		//      (mirrors what ModelAnimation::PrepDraw does for stock entries).
+		//   2. Install a hash remap so draw commands using `stock_entry` get
+		//      redirected to the variant entry at dispatch time.
+		//
+		// Variant textures resolve through the variant's own `GMD+0x40`
+		// (texture name hashes written by AddModelData).  No vcount/topology
+		// constraints; stock state is never mutated.
+		//
+		// **Example Usage:**
+		// ```lua
+		// rom.data.swap_to_variant("HecateHub_Mesh", "HecateHub_Variant_Mesh")
+		// -- later:
+		// rom.data.restore_stock("HecateHub_Mesh")
+		// ```
+		ns.set_function("swap_to_variant", [](const std::string& stock_entry,
+		                                       const std::string& variant_entry) -> bool {
+			// Just install the hash remap.  Texture handles (GMD+0x44) must be
+			// populated ahead of time via populate_entry_textures at a known-safe
+			// window (first ImGui frame, after LoadAllModelAndAnimationData).
+			// Calling GetTexture from the render-thread ImGui callback while the
+			// game thread is actively rendering the target entry deadlocks the
+			// render pipeline (observed: "Waiting for RenderCommands to be ready
+			// to write").  Keeping this path to a single atomic map write makes
+			// swaps cheap and thread-safe.
+			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
+			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
+			if (!Lookup) { LOG(ERROR) << "swap_to_variant: Lookup missing"; return false; }
+
+			sgg::HashGuid variant_guid{};
+			Lookup(&variant_guid, variant_entry.c_str(), variant_entry.size());
+			if (!variant_guid.mId)
+			{
+				LOG(WARNING) << "swap_to_variant: variant hash=0 ('" << variant_entry << "')";
+				return false;
+			}
+			sgg::HashGuid stock_guid{};
+			Lookup(&stock_guid, stock_entry.c_str(), stock_entry.size());
+			if (!stock_guid.mId)
+			{
+				LOG(WARNING) << "swap_to_variant: stock hash=0 ('" << stock_entry << "')";
+				return false;
+			}
+
+			{
+				std::unique_lock l(g_mutex);
+				g_remap[stock_guid.mId] = variant_guid.mId;
+			}
+			update_active_flag();
+
+			LOG(INFO) << "swap_to_variant: '" << stock_entry << "' -> '" << variant_entry << "'";
+			return true;
+		});
+
+		// Lua API: Function
+		// Table: data
+		// Name: restore_stock
+		// Param: stock_entry: string: Stock entry name to revert to.
+		// Returns: boolean — true on success.
+		// Clears any active hash remap for the given stock entry.  No-op if no
+		// remap is active.  Populated variant GMD+0x44 handles are left in place
+		// (they're harmless — only used when a remap is active).
+		ns.set_function("restore_stock", [](const std::string& stock_entry) -> bool {
+			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
+			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
+			sgg::HashGuid stock{};
+			Lookup(&stock, stock_entry.c_str(), stock_entry.size());
+			if (!stock.mId)
+			{
+				LOG(WARNING) << "restore_stock: hash=0 ('" << stock_entry << "')";
+				return false;
+			}
+			{
+				std::unique_lock l(g_mutex);
+				g_remap.erase(stock.mId);
+			}
+			update_active_flag();
+			LOG(INFO) << "restore_stock: '" << stock_entry << "' remap cleared";
 			return true;
 		});
 

--- a/src/lua_extensions/bindings/hades/draw.cpp
+++ b/src/lua_extensions/bindings/hades/draw.cpp
@@ -6,6 +6,9 @@
 ///   rom.data.set_draw_visible(entry, visible)
 ///     Show/hide an entire entry across all draw passes.
 ///
+///   rom.data.set_mesh_visible(entry, mesh_name, visible)
+///     Show/hide a single mesh inside an entry.
+///
 ///   rom.data.dump_pool_stats()
 ///     Diagnostic: log vertex/index pool cursor + capacity per
 ///     shader effect.
@@ -23,10 +26,12 @@
 #include <hades2/pdb_symbol_map.hpp>
 #include <hooks/hooking.hpp>
 #include <lua/lua_manager.hpp>
+#include <map>
 #include <memory/gm_address.hpp>
 #include <mutex>
 #include <shared_mutex>
 #include <string/string.hpp>
+#include <tuple>
 
 namespace lua::hades::draw
 {
@@ -370,6 +375,157 @@ namespace lua::hades::draw
 				          << (imsize / (1024.0 * 1024.0)) << " MB (" << ipct << "%)";
 			}
 			return logged;
+		});
+		// Lua API: Function
+		// Table: data
+		// Name: set_mesh_visible
+		// Param: entry_name: string: Model entry (e.g. "HecateHub_Mesh").
+		// Param: mesh_name: string: Mesh name inside that entry (e.g. "TorusHubMesh").
+		// Param: visible: boolean: true to show, false to hide.
+		// Returns: boolean — true on success.
+		//
+		// Finer-grained than set_draw_visible (which hides the whole entry):
+		// walks the entry's GrannyMeshData vector, finds the mesh whose
+		// mesh-name hash at GMD+0x48 matches `mesh_name`, and flips its
+		// texture-name hash at GMD+0x40 between 0 (hide) and the original
+		// value (show).
+		//
+		// Hide path uses DoDraw3D's OWN mesh-type switch: setting
+		// GMD+0x4C = 2 makes the main-draw function skip to
+		// next-iteration at 0x1401ebd25 — no cmdDrawIndexed is issued,
+		// no texture lookup attempted.  This is the same branch the
+		// engine takes for its own shadow meshes (they're drawn via
+		// DoDrawShadow3D instead, which our accessory meshes don't
+		// have a shadow entry in, so they stay hidden everywhere).
+		// No DX12 validation errors, no command-list poisoning.
+		//
+		// Used for instant accessory toggle: mesh_add mods merge their
+		// meshes INTO stock entries, so the entry-level draw-gate would
+		// hide the body alongside the accessory.  Per-mesh visibility
+		// keeps the body on and only suppresses the accessory meshes.
+		ns.set_function("set_mesh_visible", [](const std::string& entry,
+		                                        const std::string& mesh_name,
+		                                        bool visible) -> bool {
+			// Saved mesh_type keyed by (entry_hash, mesh_hash, idx).  Index
+			// distinguishes multiple GMDs sharing the same name hash
+			// (e.g. main+outline+shadow variants under a shared name, or
+			// duplicate GLB meshes split by material).  Using raw GMD
+			// pointer would be invalidated if the GMD vector ever
+			// reallocates — unlikely in Hades II's static-load model but
+			// not guaranteed by the engine contract.  std::map so we
+			// don't have to write a tuple hasher.
+			using SavedKey = std::tuple<uint32_t, uint32_t, size_t>;
+			static std::map<SavedKey, uint8_t> g_saved_mesh_type;
+			static std::mutex g_saved_mutex;
+
+			static auto Lookup = *big::hades2_symbol_to_address["sgg::HashGuid::Lookup"]
+			    .as_func<sgg::HashGuid*(sgg::HashGuid*, const char*, size_t)>();
+			auto mdata_addr = big::hades2_symbol_to_address["sgg::Granny3D::mModelData"];
+			if (!Lookup || !mdata_addr)
+			{
+				LOG(ERROR) << "set_mesh_visible: required symbols missing";
+				return false;
+			}
+
+			sgg::HashGuid entry_guid{};
+			Lookup(&entry_guid, entry.c_str(), entry.size());
+			if (!entry_guid.mId)
+			{
+				LOG(WARNING) << "set_mesh_visible: entry hash=0 for '" << entry << "'";
+				return false;
+			}
+			sgg::HashGuid mesh_guid{};
+			Lookup(&mesh_guid, mesh_name.c_str(), mesh_name.size());
+			if (!mesh_guid.mId)
+			{
+				LOG(WARNING) << "set_mesh_visible: mesh hash=0 for '" << mesh_name << "'";
+				return false;
+			}
+
+			uint8_t* mdata = mdata_addr.as<uint8_t*>();
+			void* buckets_ptr = nullptr;
+			uint64_t bucket_count = 0;
+			if (!safe_read_ptr(mdata + 0x08, &buckets_ptr)) return false;
+			if (!safe_read_u64(mdata + 0x10, &bucket_count)) return false;
+			if (!buckets_ptr || !bucket_count || bucket_count > 0x100000) return false;
+
+			uint32_t h = entry_guid.mId;
+			h = ((h >> 16) ^ h) * 0x7feb352d;
+			h = ((h >> 15) ^ h) * 0x846ca68b;
+			h = (h >> 16) ^ h;
+			uint8_t* node = (uint8_t*)((void**)buckets_ptr)[h % bucket_count];
+			int walk_guard = 0;
+			while (node && walk_guard++ < 32)
+			{
+				uint32_t id = 0;
+				if (!safe_read_u32(node, &id)) return false;
+				if (id == entry_guid.mId) break;
+				void* nxt = nullptr;
+				if (!safe_read_ptr(node + 0xC0, &nxt)) return false;
+				node = (uint8_t*)nxt;
+			}
+			if (!node || walk_guard >= 32)
+			{
+				LOG(WARNING) << "set_mesh_visible: entry '" << entry << "' not in mModelData";
+				return false;
+			}
+
+			void* vb_p = nullptr; void* ve_p = nullptr;
+			if (!safe_read_ptr(node + 0x10, &vb_p)) return false;
+			if (!safe_read_ptr(node + 0x18, &ve_p)) return false;
+			uint8_t* vec_begin = (uint8_t*)vb_p;
+			uint8_t* vec_end   = (uint8_t*)ve_p;
+			size_t mesh_count = (vec_end >= vec_begin) ? (size_t)(vec_end - vec_begin) / 0x50 : 0;
+			if (mesh_count == 0 || mesh_count > 128) return false;
+
+			// Sentinel byte used for hidden state (= shadow mesh type,
+			// which DoDraw3D skips to next-iteration).
+			constexpr uint8_t HIDE_TYPE = 2;
+			int matched = 0;
+			std::lock_guard lk(g_saved_mutex);
+			for (size_t i = 0; i < mesh_count; i++)
+			{
+				uint8_t* gmd = vec_begin + i * 0x50;
+				uint32_t gmd_mesh_hash = 0;
+				if (!safe_read_u32(gmd + 0x48, &gmd_mesh_hash)) continue;
+				if (gmd_mesh_hash != mesh_guid.mId) continue;
+
+				uint8_t current_type = *(uint8_t*)(gmd + 0x4C);
+				SavedKey key{entry_guid.mId, mesh_guid.mId, i};
+
+				if (visible)
+				{
+					auto it = g_saved_mesh_type.find(key);
+					if (it != g_saved_mesh_type.end())
+					{
+						*(uint8_t*)(gmd + 0x4C) = it->second;
+						g_saved_mesh_type.erase(it);
+					}
+					// else: already visible — no-op
+				}
+				else
+				{
+					if (current_type != HIDE_TYPE && !g_saved_mesh_type.count(key))
+					{
+						g_saved_mesh_type[key] = current_type;
+						*(uint8_t*)(gmd + 0x4C) = HIDE_TYPE;
+					}
+					// else: already hidden — no-op
+				}
+				matched++;
+				// Don't break: continue so main+outline+shadow variants
+				// with the same mesh-name hash all get toggled together.
+			}
+			if (matched == 0)
+			{
+				LOG(WARNING) << "set_mesh_visible: mesh '" << mesh_name
+				             << "' not in entry '" << entry << "'";
+				return false;
+			}
+			LOG(INFO) << "set_mesh_visible: " << entry << "/" << mesh_name
+			          << " -> " << (visible ? "show" : "hide")
+			          << " (" << matched << " mesh" << (matched > 1 ? "es" : "") << ")";
+			return true;
 		});
 
 		// NOTE: No hook on LoadAllModelAndAnimationData — a second detour

--- a/src/lua_extensions/bindings/hades/draw.hpp
+++ b/src/lua_extensions/bindings/hades/draw.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace lua::hades::draw
+{
+	void bind(sol::state_view& state, sol::table& lua_ext);
+}

--- a/src/lua_extensions/lua_manager_extension.cpp
+++ b/src/lua_extensions/lua_manager_extension.cpp
@@ -3,6 +3,7 @@
 #include "bindings/gui_ext.hpp"
 #include "bindings/hades/audio.hpp"
 #include "bindings/hades/data.hpp"
+#include "bindings/hades/draw.hpp"
 #include "bindings/hades/inputs.hpp"
 #include "bindings/hades/gpk.hpp"
 #include "bindings/hades/tethers.hpp"
@@ -319,6 +320,7 @@ namespace big::lua_manager_extension
 		// Let's keep that list sorted the same as the solution file explorer
 		lua::hades::audio::bind(lua_ext);
 		lua::hades::data::bind(state, lua_ext);
+		lua::hades::draw::bind(state, lua_ext);
 		lua::hades::inputs::bind(state, lua_ext);
 		lua::hades::gpk::bind(lua_ext);
 		lua::hades::tethers::bind(state, lua_ext);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2342,6 +2342,89 @@ extern "C" __declspec(dllexport) void my_main()
 		}
 	}
 
+	// Raise the static vertex + index pool sizes.  Mods that add extra
+	// character mesh entries blow through the default budgets, causing
+	// RequestBufferUpdate to fail on later-loaded meshes (weapons,
+	// enemies) — they fall back to the placeholder "blank mesh" prop.
+	//
+	// Both buffers live in the DX12 upload heap (system RAM, not VRAM),
+	// so the extra capacity costs a few dozen MB of RAM.
+	//
+	// Must run before ForgeRenderer init fires at game startup.
+	// my_main() runs at DLL attach, safely before that.  The config
+	// values are read here once; changing them in the UI requires a
+	// game restart.
+	static auto vertex_pool_mb = big::config::general->bind(
+	    "Pool Sizes", "Static Vertex Pool (MB)", 128,
+	    "Static vertex buffer pool allocated per shader effect.  Game "
+	    "default is 64 MB.  Raise if mods adding many character mesh "
+	    "entries cause weapons or enemies to render as the placeholder "
+	    "'blank mesh' prop.  Lives in the DX12 upload heap (system RAM, "
+	    "not VRAM).  Applied at DLL attach — restart to change.");
+
+	static auto index_pool_mb = big::config::general->bind(
+	    "Pool Sizes", "Static Index Pool (MB)", 64,
+	    "Static index buffer pool allocated once globally.  Game default "
+	    "is 32 MB.  Raise together with the vertex pool.");
+
+	// Patch site: `mov qword [rsp+X], imm32`.  Bytes 0-4 = opcode + SIB +
+	// disp8; bytes 5-8 = the imm32 operand (sign-extended to 64 bits).
+	// Writing the full imm32 lets us reach any size up to 2 GB, not just
+	// the 16 MB-aligned values a single-byte patch allows.
+	auto patch_pool_size = [](const char* label, const char* sig,
+	                          const char* scan_name,
+	                          uint32_t game_default_bytes,
+	                          uint32_t target_bytes) -> bool
+	{
+		if (target_bytes == game_default_bytes)
+		{
+			LOG(INFO) << "Pool patch: [SKIP] " << label
+			          << " (matches game default)";
+			return false;
+		}
+		if (target_bytes < game_default_bytes)
+		{
+			LOG(WARNING) << "Pool patch: [SKIP] " << label
+			             << " (configured " << (target_bytes >> 20)
+			             << " MB < game default " << (game_default_bytes >> 20)
+			             << " MB — refusing to shrink)";
+			return false;
+		}
+		auto scan = gmAddress::scan(sig, scan_name);
+		if (!scan)
+		{
+			LOG(WARNING) << "Pool patch: [SKIP] " << label
+			             << " (pattern not found — game update?)";
+			return false;
+		}
+		auto imm32 = scan.offset(5).as<uint32_t*>();
+		if (*imm32 != game_default_bytes)
+		{
+			LOG(WARNING) << "Pool patch: [SKIP] " << label
+			             << " (expected imm32=" << HEX_TO_UPPER(game_default_bytes)
+			             << ", got " << HEX_TO_UPPER(*imm32) << ")";
+			return false;
+		}
+		ForceWrite<uint32_t>(*imm32, target_bytes);
+		LOG(INFO) << "Pool patch: [OK  ] " << label << " "
+		          << (game_default_bytes >> 20) << " MB -> "
+		          << (target_bytes >> 20) << " MB";
+		return true;
+	};
+
+	const uint32_t vertex_target = (uint32_t)vertex_pool_mb->get_value() << 20;
+	const uint32_t index_target  = (uint32_t)index_pool_mb->get_value()  << 20;
+
+	patch_pool_size("Vertex Pool",
+	    "48 C7 44 24 20 00 00 00 04 E8",
+	    "mov [rsp+0x20], 64MB (vertex pool size in sgg::addShaderEffect)",
+	    0x04000000u, vertex_target);
+
+	patch_pool_size("Index Pool",
+	    "48 C7 44 24 40 00 00 00 02 48",
+	    "mov [rsp+0x40], 32MB (index pool size in sgg::addStaticVertexBuffers)",
+	    0x02000000u, index_target);
+
 	const auto initRenderer_ptr = big::hades2_symbol_to_address["initRenderer"];
 	if (initRenderer_ptr)
 	{


### PR DESCRIPTION
Adds `rom.data.*` Lua bindings for live control of 3D model rendering (hide individual meshes, swap bodies, toggle variants) without mutating engine state.
Additionally, raises the static GPU buffer pool sizes (user-configurable) to prevent mods with many character meshes from falling back to the "blank mesh" placeholder.


---

## Primer

Hades II organises a character's 3D data in a three-level hierarchy:

- **Model** - everything the game loads for a character (all their outfits, shadows, outlines). 
Equal to model data naming in engine.
- **Entry** - a named slot inside a model. The same character can have several.
Each entry is rendered independently. The game looks entries up by hashing their name.
- **Mesh** - a single piece of geometry inside an entry. An entry typically holds a handful of these and renders them as a set.

Hierarchy: **model → entry → mesh.** The new bindings let mods switch an entry's content, hide a whole entry, or hide one mesh inside an entry without touching the loaded model data or reloading anything.

---

## New Lua bindings

All in `src/lua_extensions/bindings/hades/draw.cpp` under `lua::hades::draw`:

| API | What it does |
|---|---|
| `rom.data.set_draw_visible(entry, visible)` | Instantly show/hide an entry from all draw passes. |
| `rom.data.set_mesh_visible(entry, mesh_name, visible)` | Instantly show/hide a mesh inside an entry. |
| `rom.data.swap_to_variant(stock, variant)` | Redirect a stock entry's draw calls to a variant entry. Works for outfit switching - the variant's textures are pre-populated so the first remapped frame renders correctly. |
| `rom.data.restore_stock(stock)` | Undo `swap_to_variant`. |
| `rom.data.populate_entry_textures(entry)` | Resolve and cache an entry's texture handles. Needed once for variant entries before the first draw. |
| `rom.data.dump_pool_stats()` | Log current vertex/index pool usage per shader effect - diagnostic for "ran out of static buffer space" errors. |

Each one is a single-frame toggle. The mod calls it, the next frame renders the new state, done. The engine's loaded model data stays untouched - nothing is reloaded, rebuilt, or reallocated. The matching "restore" / "clear" call reverts the toggle just as cheaply.

---

## Static buffer pool patches

Prevents the "blank mesh" fallback the engine uses when its per-shader-effect vertex pool or global index pool runs out. Mods adding many character mesh entries (outfit variants, large accessory packs) otherwise exhaust the default budgets and later-loaded meshes - weapons and enemies typically - fall back to the placeholder prop.

Two `rom.data.config` entries bound under a new **"Pool Sizes"** section of H2M's config UI, read once at DLL attach:

| Config | Default | Game default |
|---|---|---|
| `Pool Sizes / Static Vertex Pool (MB)` | 128 | 64 |
| `Pool Sizes / Static Index Pool (MB)`  | 64  | 32 |

Implementation rewrites the full `imm32` operand of the `mov qword [rsp+X], imm32` at each pool's allocation site (vertex pool in `sgg::addShaderEffect`, index pool in `sgg::addStaticVertexBuffers`), so any size up to 2 GB can be set from config.

Both pools live in the DX12 upload heap (system RAM, not VRAM). Applied at `my_main()` time; changes to the config require a restart to take effect.

Each patch logs `[OK]` or `[SKIP]` at attach with a reason:
- `SKIP` if the configured value matches the game default (no-op)
- `SKIP` if the configured value is below the game default (refused - no game-shrinking)
- `SKIP` if the scan pattern isn't found or the expected `imm32` isn't at the site (game update likely shifted the byte pattern)
- `OK` with a `from → to MB` line on success

---

## Scope

- **No persistent state mutation.** All new state is in `static std::map`s guarded by a single `std::shared_mutex`, cleared by the matching `restore`/`clear_draw_remap` call.
- **Graceful missing symbols.** Each hook installs only if its symbol resolves; otherwise the binding is a no-op with a warning.
- **Self-contained.** 1 new .cpp + 1 new .hpp under `lua::hades::draw`; `main.cpp` gains the two pool patches + status log; `data.cpp` + `lua_manager_extension.cpp` each gain one line to register the namespace.

---

Four commits, ~890 lines added total:

1. **Raise static GPU buffer pool sizes (configurable)** - `main.cpp` only, pool patches + config bindings.
2. **Add draw-path hooks + `set_draw_visible` + `dump_pool_stats`** - creates `draw.cpp`/`draw.hpp`, detour + code-cave infrastructure, visibility binding + pool diagnostic.
3. **Add `rom.data.set_mesh_visible`** - per-mesh visibility, stacks on #2.
4. **Add variant-switching Lua APIs** - `swap_to_variant` / `restore_stock` / `populate_entry_textures`, stacks on #2.
