### PR TITLE
feat(VO): Enable custom voice bank loading, skip engine mActor check

### DIFF
--- a/src/hades2/plugin_file_registry.hpp
+++ b/src/hades2/plugin_file_registry.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
+struct vo_file_registry
+{
+	std::unordered_map<std::string, std::string> fsb_files;
+	std::unordered_map<std::string, std::string> txt_files;
+};
+
+extern vo_file_registry additional_vo_files;
+extern std::shared_mutex g_plugin_files_mutex;
+
+// Validates that a voice bank stem name (e.g. "Authornamemodnamevoicebank") is compatible with
+// the engine's cue normalization. The engine lowercases characters at positions 2+
+// of the bank name (within the "/VO/" prefixed cue string), then re-uppercases the
+// first character of the substrings "field" and "keepsake". Any other uppercase
+// letters *after the first character* will cause a mismatch between the stored cue key
+// and the Lua-side cue reference.
+// Returns true if the name is safe, false if it would cause lookup failures.
+inline bool validate_vo_bank_name(const std::string& stem)
+{
+	if (stem.empty())
+	{
+		return false;
+	}
+
+	// Simulate the engine's normalization: lowercase everything after the first character,
+	// then re-uppercase 'f' in "field" and 'k' in "keepsake".
+	std::string normalized = stem;
+	for (size_t i = 1; i < normalized.size(); i++)
+	{
+		normalized[i] = (char)std::tolower((unsigned char)normalized[i]);
+	}
+
+	for (const char* keyword : {"field", "keepsake"})
+	{
+		auto pos = normalized.find(keyword, 1);
+		if (pos != std::string::npos)
+		{
+			normalized[pos] = (char)std::toupper((unsigned char)normalized[pos]);
+		}
+	}
+
+	return normalized == stem;
+}

--- a/src/lua_extensions/bindings/hades/audio.cpp
+++ b/src/lua_extensions/bindings/hades/audio.cpp
@@ -3,11 +3,77 @@
 #include <hades2/pdb_symbol_map.hpp>
 #include <hooks/hooking.hpp>
 #include <lua_extensions/bindings/tolk/tolk.hpp>
+#include <memory/byte_patch.hpp>
 #include <memory/gm_address.hpp>
 #include <string/string.hpp>
 
 namespace lua::hades::audio
 {
+	// Bypasses the AudioData::Data.mActors membership check in LoadVoiceBank,
+	// allowing voice banks with any name to be loaded (not just registered actors).
+	// The check is purely a validation gate - no data from the found mActors entry
+	// is used after the check, and invalid bank names fail gracefully at the FMOD
+	// file-loading stage (FMOD_ERR_FILE_NOTFOUND is silently ignored).
+	static void patch_LoadVoiceBank_actor_check()
+	{
+		static auto LoadVoiceBank_ptr = big::hades2_symbol_to_address["sgg::AudioManager::LoadVoiceBank"];
+		if (!LoadVoiceBank_ptr)
+		{
+			LOG(WARNING) << "sgg::AudioManager::LoadVoiceBank not found in PDB; custom voice banks disabled";
+			return;
+		}
+
+		// The mActors search loop ends with:
+		//   cmp rbx, rdi          ; puVar27 != mActors end?
+		//   je  <exit>            ; skip loading if actor not found (6-byte je near: 0F 84 xx xx xx xx)
+		//   call getUSec          ; loading path starts here
+		//
+		// We scan for the distinctive loop tail: add rbx,0x30 / cmp rbx,rdi
+		// The je gate is 9 bytes after the add instruction.
+		//
+		// Pattern: 48 83 C3 30  (add rbx, 0x30)
+		//          48 3B DF     (cmp rbx, rdi)
+		//          75 ??        (jne loop_top)
+		//          48 3B DF     (cmp rbx, rdi)
+		//          0F 84        (je near - the gate)
+		auto func_base = LoadVoiceBank_ptr.as<uint8_t*>();
+
+		// Scan within the first 0x300 bytes of the function for the mActors loop tail
+		uint8_t* gate_addr = nullptr;
+		for (size_t i = 0; i + 16 < 0x300; i++)
+		{
+			// Match: add rbx, 0x30 / cmp rbx, rdi / jne ?? / cmp rbx, rdi / je near
+			if (func_base[i]     == 0x48 && func_base[i + 1] == 0x83 &&
+			    func_base[i + 2] == 0xC3 && func_base[i + 3] == 0x30 && // add rbx, 0x30
+			    func_base[i + 4] == 0x48 && func_base[i + 5] == 0x3B &&
+			    func_base[i + 6] == 0xDF &&                              // cmp rbx, rdi
+			    func_base[i + 7] == 0x75 &&                              // jne (short)
+			    func_base[i + 9] == 0x48 && func_base[i + 10] == 0x3B &&
+			    func_base[i + 11] == 0xDF &&                             // cmp rbx, rdi
+			    func_base[i + 12] == 0x0F && func_base[i + 13] == 0x84)  // je (near)
+			{
+				gate_addr = func_base + i + 12;
+				break;
+			}
+		}
+
+		if (!gate_addr)
+		{
+			LOG(WARNING) << "LoadVoiceBank actor-check branch not found; custom voice banks disabled";
+			return;
+		}
+
+		// NOP the 6-byte conditional jump (je near: 0F 84 xx xx xx xx)
+		static constexpr uint8_t nops[] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+		static_assert(sizeof(nops) == 6);
+		for (size_t i = 0; i < sizeof(nops); i++)
+		{
+			memory::byte_patch::make(gate_addr + i, nops[i])->apply();
+		}
+
+		LOG(INFO) << "Patched LoadVoiceBank actor check - custom voice banks enabled";
+	}
+
 	static std::string g_fixed_path_fsAppendPathComponent;
 
 	static void hook_fsAppendPathComponent(const char* basePath, const char* pathComponent, char* output /*size: 512*/)
@@ -69,6 +135,11 @@ namespace lua::hades::audio
 		}
 
 		return false;
+	}
+
+	void init()
+	{
+		patch_LoadVoiceBank_actor_check();
 	}
 
 	void bind(sol::table& state)

--- a/src/lua_extensions/bindings/hades/audio.hpp
+++ b/src/lua_extensions/bindings/hades/audio.hpp
@@ -2,5 +2,6 @@
 
 namespace lua::hades::audio
 {
+	void init();
 	void bind(sol::table& state);
 }

--- a/src/lua_extensions/bindings/hades/data.cpp
+++ b/src/lua_extensions/bindings/hades/data.cpp
@@ -24,15 +24,9 @@ namespace sgg
 
 extern std::unordered_map<std::string, std::string> additional_map_files;
 
-struct vo_file_registry
-{
-	std::unordered_map<std::string, std::string> fsb_files;
-	std::unordered_map<std::string, std::string> txt_files;
-};
-extern vo_file_registry additional_vo_files;
+#include "hades2/plugin_file_registry.hpp"
 
 extern std::unordered_map<std::string, std::string> additional_bik_files;
-extern std::shared_mutex g_plugin_files_mutex;
 extern int ends_with(const char* str, const char* suffix);
 
 // Defined in main.cpp: file redirect maps for custom GPK/PKG assets

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@
 #include <DbgHelp.h>
 #include <hades2/pdb_symbol_map.hpp>
 #include <lua_extensions/bindings/hades/data.hpp>
+#include "hades2/plugin_file_registry.hpp"
+#include <lua_extensions/bindings/hades/audio.hpp>
 #include <lua_extensions/bindings/hades/hades_ida.hpp>
 #include <lua_extensions/bindings/hades/inputs.hpp>
 #include <lua_extensions/bindings/paths_ext.hpp>
@@ -1668,12 +1670,6 @@ std::unordered_map<std::string, std::string> additional_granny_files;
 
 std::unordered_map<std::string, std::string> additional_map_files;
 
-struct vo_file_registry
-{
-	std::unordered_map<std::string, std::string> fsb_files;
-	std::unordered_map<std::string, std::string> txt_files;
-};
-
 vo_file_registry additional_vo_files;
 
 std::unordered_map<std::string, std::string> additional_bik_files;
@@ -2876,6 +2872,10 @@ extern "C" __declspec(dllexport) void my_main()
 	}
 
 	{
+		lua::hades::audio::init();
+	}
+
+	{
 		static auto ptr = big::hades2_symbol_to_address["sgg::LaunchBugReporter"];
 		if (ptr)
 		{
@@ -3114,10 +3114,21 @@ extern "C" __declspec(dllexport) void my_main()
 		}
 		else if (entry.path().extension() == ".fsb")
 		{
-			additional_vo_files.fsb_files.emplace((char *)entry.path().filename().u8string().c_str(),
-			                                      (char *)entry.path().u8string().c_str());
+			const auto stem = std::string((char*)entry.path().stem().u8string().c_str());
+			if (!validate_vo_bank_name(stem))
+			{
+				LOG(WARNING) << "Custom voice banks may only have the first letter capitalized, "
+				                "except when containing \"Field\" or \"Keepsake\" which must always be capitalized. "
+				                "Otherwise the engine will not be able to resolve your cues. "
+				                "The voice bank that failed validation and will not be added: \"" << stem << "\"";
+			}
+			else
+			{
+				additional_vo_files.fsb_files.emplace((char *)entry.path().filename().u8string().c_str(),
+				                                      (char *)entry.path().u8string().c_str());
 
-			LOG(INFO) << "Adding to VO files: " << (char *)entry.path().u8string().c_str();
+				LOG(INFO) << "Adding to VO files: " << (char *)entry.path().u8string().c_str();
+			}
 		}
 		else if (entry.path().extension() == ".bik" || entry.path().extension() == ".bik_atlas")
 		{


### PR DESCRIPTION
Example excerpt from logs:
```
[INFO/audio.cpp:74] Patched LoadVoiceBank actor check - custom voice banks enabled
[INFO/main.cpp:3130] Adding to VO files: C:\Users\nikke\AppData\Roaming\r2modmanPlus-local\HadesII\profiles\Default\ReturnOfModding\plugins_data\NikkelM-Zagreus_Journey\Content\Audio\Desktop\VO\Modsnikkelmhadesbiomesskelly.fsb
[WARNING/main.cpp:3120] Custom voice banks may only have the first letter capitalized, except when containing "Field" or "Keepsake" which must always be capitalized. Otherwise the engine will not be able to resolve your cues. Custom voice bank that failed the validation: "ModsnikkelmhadesbiomesskellyCopy"
```