### PR TITLE
Call keybind shortcuts in a "thread"

### DIFF
--- a/src/lua_extensions/bindings/hades/inputs.cpp
+++ b/src/lua_extensions/bindings/hades/inputs.cpp
@@ -328,7 +328,9 @@ namespace lua::hades::inputs
 				for (auto &cb : it_callback->second)
 				{
 					LOG(DEBUG) << cb.name << " (Vanilla)";
-					cb.cb();
+					sol::state_view lua(big::g_lua_manager->lua_state());
+					sol::function luaThread = lua["thread"];
+					luaThread(cb.cb);
 				}
 			}
 		}
@@ -345,13 +347,15 @@ namespace lua::hades::inputs
 				for (auto &cb : it_callback->second)
 				{
 					LOG(DEBUG) << cb.name;
-					cb.cb();
+					sol::state_view lua(big::g_lua_manager->lua_state());
+					sol::function luaThread = lua["thread"];
+					luaThread(cb.cb);
 				}
 			}
 		}
 	}
 
-	static void parse_and_register_keybind(std::string &keybind, const sol::coroutine &callback, const std::string &name, auto &RegisterDebugKey, bool is_vanilla, big::lua_module_ext *mod)
+	static void parse_and_register_keybind(std::string &keybind, const sol::function &callback, const std::string &name, auto &RegisterDebugKey, bool is_vanilla, big::lua_module_ext *mod)
 	{
 		eastl_custom::function<void(uintptr_t)> funcy;
 		funcy.mMgrFuncPtr    = nullptr;
@@ -435,7 +439,7 @@ namespace lua::hades::inputs
 			if (RegisterDebugKey)
 			{
 				auto keybind_opt       = args[1].get<std::optional<std::string>>();
-				auto callback_opt      = args[2].get<std::optional<sol::coroutine>>();
+				auto callback_opt      = args[2].get<std::optional<sol::function>>();
 				auto callback_name_opt = args["Name"].get<std::optional<std::string>>();
 
 				if (keybind_opt.has_value() && keybind_opt->size() && callback_opt.has_value() && callback_opt->valid())
@@ -489,7 +493,7 @@ namespace lua::hades::inputs
 			if (RegisterDebugKey)
 			{
 				auto keybind_opt       = args[1].get<std::optional<std::string>>();
-				auto callback_opt      = args[2].get<std::optional<sol::coroutine>>();
+				auto callback_opt      = args[2].get<std::optional<sol::function>>();
 				auto callback_name_opt = args["Name"].get<std::optional<std::string>>();
 				auto is_safe_opt       = args["Safe"].get<std::optional<bool>>();
 

--- a/src/lua_extensions/bindings/hades/inputs.cpp
+++ b/src/lua_extensions/bindings/hades/inputs.cpp
@@ -355,7 +355,7 @@ namespace lua::hades::inputs
 		}
 	}
 
-	static void parse_and_register_keybind(std::string &keybind, const sol::function &callback, const std::string &name, auto &RegisterDebugKey, bool is_vanilla, big::lua_module_ext *mod)
+	static void parse_and_register_keybind(std::string &keybind, const sol::coroutine &callback, const std::string &name, auto &RegisterDebugKey, bool is_vanilla, big::lua_module_ext *mod)
 	{
 		eastl_custom::function<void(uintptr_t)> funcy;
 		funcy.mMgrFuncPtr    = nullptr;
@@ -439,7 +439,7 @@ namespace lua::hades::inputs
 			if (RegisterDebugKey)
 			{
 				auto keybind_opt       = args[1].get<std::optional<std::string>>();
-				auto callback_opt      = args[2].get<std::optional<sol::function>>();
+				auto callback_opt      = args[2].get<std::optional<sol::coroutine>>();
 				auto callback_name_opt = args["Name"].get<std::optional<std::string>>();
 
 				if (keybind_opt.has_value() && keybind_opt->size() && callback_opt.has_value() && callback_opt->valid())
@@ -493,7 +493,7 @@ namespace lua::hades::inputs
 			if (RegisterDebugKey)
 			{
 				auto keybind_opt       = args[1].get<std::optional<std::string>>();
-				auto callback_opt      = args[2].get<std::optional<sol::function>>();
+				auto callback_opt      = args[2].get<std::optional<sol::coroutine>>();
 				auto callback_name_opt = args["Name"].get<std::optional<std::string>>();
 				auto is_safe_opt       = args["Safe"].get<std::optional<bool>>();
 

--- a/src/lua_extensions/bindings/hades/inputs.hpp
+++ b/src/lua_extensions/bindings/hades/inputs.hpp
@@ -8,7 +8,7 @@ namespace lua::hades::inputs
 	struct keybind_callback
 	{
 		std::string name;
-		sol::function cb;
+		sol::coroutine cb;
 	};
 
 	extern std::map<std::string, std::vector<keybind_callback>> vanilla_key_callbacks;

--- a/src/lua_extensions/bindings/hades/inputs.hpp
+++ b/src/lua_extensions/bindings/hades/inputs.hpp
@@ -8,7 +8,7 @@ namespace lua::hades::inputs
 	struct keybind_callback
 	{
 		std::string name;
-		sol::coroutine cb;
+		sol::function cb;
 	};
 
 	extern std::map<std::string, std::vector<keybind_callback>> vanilla_key_callbacks;


### PR DESCRIPTION
Fixes debug functions like `DebugSpawnEnemy` and `OpenRunClearScreen` which were expecting to executing in "thread".

Tested modded keybinds through DamageMeter the mod.